### PR TITLE
Fix the find/search functionality

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -420,10 +420,28 @@ impl<S: Read + Write> Client<S> {
     // TODO: list type [filtertype] [filterwhat] [...] [group] [grouptype] [...]
     // TODO: searchaddpl name type what [...], readcomments
 
-    /// Initiate query to songs database
-    pub fn query<'a>(&'a mut self) -> Query<'a, S> {
-        Query::new(self)
+    /// Find songs matching Query conditions.
+    pub fn find(&mut self, query: &Query) -> Result<Vec<Song>> {
+        self.find_generic("find", query)
     }
+
+    /// Case-insensitively search for songs matching Query conditions.
+    pub fn search(&mut self, query: &Query) -> Result<Vec<Song>> {
+        self.find_generic("search", query)
+    }
+
+    fn find_generic(&mut self, cmd: &str, query: &Query) -> Result<Vec<Song>> {
+        let args = query.to_string();
+
+        self.run_command_fmt(format_args!("{} {}", cmd, args))
+            .and_then(|_| {
+                self.read_pairs()
+                    .split("file")
+                    .map(|v| v.and_then(FromMap::from_map))
+                    .collect()
+            })
+    }
+
     // }}}
 
     // Output methods {{{

--- a/src/search.rs
+++ b/src/search.rs
@@ -35,65 +35,38 @@ impl<'a> Filter<'a> {
     }
 }
 
-pub struct Query<'a, S: 'a + Read + Write> {
-    client: &'a mut Client<S>,
+pub struct Query<'a> {
     filters: Vec<Filter<'a>>,
     groups: Option<Vec<Cow<'a, str>>>,
     window: Option<(u32, u32)>,
 }
 
-impl<'a, S: 'a + Read + Write> Query<'a, S> {
-    pub fn new(client: &'a mut Client<S>) -> Query<'a, S> {
+impl<'a> Query<'a> {
+    pub fn new() -> Query<'a> {
         Query {
-            client: client,
             filters: Vec::new(),
             groups: None,
             window: None,
         }
     }
 
-    pub fn and<'b: 'a, V: 'b + Into<Cow<'b, str>>>(&'a mut self, term: Term<'b>, value: V) -> &'a mut Query<'a, S> {
+    pub fn and<'b: 'a, V: 'b + Into<Cow<'b, str>>>(&'a mut self, term: Term<'b>, value: V) -> &'a mut Query<'a> {
         self.filters.push(Filter::new(term, value));
         self
     }
 
-    pub fn limit(&'a mut self, offset: u32, limit: u32) -> &'a mut Query<'a, S> {
+    pub fn limit(&'a mut self, offset: u32, limit: u32) -> &'a mut Query<'a> {
         self.window = Some((offset, limit));
         self
     }
 
-    pub fn group<'b: 'a, G: 'b + Into<Cow<'b, str>>>(&'a mut self, group: G) -> &'a mut Query<'a, S> {
+    pub fn group<'b: 'a, G: 'b + Into<Cow<'b, str>>>(&'a mut self, group: G) -> &'a mut Query<'a> {
         match self.groups {
             None => self.groups = Some(vec![group.into()]),
             Some(ref mut groups) => groups.push(group.into()),
         };
         self
     }
-
-    pub fn find(mut self, fuzzy: bool, add: bool) -> Result<Vec<Song>> {
-        let cmd = if fuzzy { if add { "searchadd" } else { "search" } } else { if add { "findadd" } else { "find" } };
-        let args = self.to_string();
-
-        self.client
-            .run_command_fmt(format_args!("{} {}", cmd, args))
-            .and_then(|_| {
-                self.client
-                    .read_pairs()
-                    .split("file")
-                    .map(|v| v.and_then(FromMap::from_map))
-                    .collect()
-            })
-    }
-
-    pub fn find_add<N: ToPlaylistName>(mut self, playlist: N) -> Result<()> {
-        let args = self.to_string();
-        self.client
-            .run_command_fmt(format_args!("searchaddpl {} {}", playlist.to_name(), args))
-            .and_then(|_| self.client.expect_ok())
-    }
-
-    // pub fn list(mut self, ty: &str) -> Result<Vec<???>> {
-    // }
 }
 
 impl<'a> fmt::Display for Term<'a> {
@@ -110,11 +83,11 @@ impl<'a> fmt::Display for Term<'a> {
 
 impl<'a> fmt::Display for Filter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}", self.typ, self.what)
+        write!(f, " {} \"{}\"", self.typ, self.what)
     }
 }
 
-impl<'a, S: 'a + Read + Write> fmt::Display for Query<'a, S> {
+impl<'a> fmt::Display for Query<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for filter in &self.filters {
             try!(filter.fmt(f));
@@ -122,7 +95,7 @@ impl<'a, S: 'a + Read + Write> fmt::Display for Query<'a, S> {
 
         if let Some(ref groups) = self.groups {
             for group in groups {
-                try!(write!(f, "group {}", group));
+                try!(write!(f, " group {}", group));
             }
         }
 

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -2,14 +2,36 @@ extern crate mpd;
 
 mod helpers;
 use helpers::connect;
+use mpd::{Query, Term};
 
 #[test]
 fn search() {
     let mut mpd = connect();
-    let mut query = mpd.query();
+    let mut query = Query::new();
     //query.and(mpd::Term::Any, "Soul");
-    let songs = query.find(false, false);
+    let songs = mpd.find(&query);
     println!("{:?}", songs);
+}
+
+#[test]
+fn find_query_format() {
+    let mut query = Query::new();
+    let finished = query
+        .and(Term::Tag("albumartist".into()), "Mac DeMarco")
+        .and(Term::Tag("album".into()), "Salad Days")
+        .limit(0, 2);
+    assert_eq!(&finished.to_string(),
+               " albumartist \"Mac DeMarco\" album \"Salad Days\" window 0:2");
+}
+
+#[test]
+fn count_query_format() {
+    let mut query = Query::new();
+    let finished = query
+        .and(Term::Tag("artist".into()), "Courtney Barnett")
+        .group("album");
+    assert_eq!(&finished.to_string(),
+               " artist \"Courtney Barnett\" group album");
 }
 
 /*


### PR DESCRIPTION
The find/search interface is now usable and correctly returns the songs
being searched for according to the Query criteria. The most important
changes are:

* Don't let Query own the Client connection, but lend the Query to the
  Client instead for the duration of the query run.

* Fix how Query struct generates its string representation (spacing,
  quoting).

(An issue that Query interface isn't fully chainable still
persists. This is possible to work around using `let` bindings for now.)

This should fix issue #4 (i'm now able to use the `find` command end-to-end in my app).