### PR TITLE
Fix the elapsed time counter

### DIFF
--- a/src/status.rs
+++ b/src/status.rs
@@ -212,7 +212,7 @@ impl FromIter for Status {
                     result.elapsed = line.1
                                          .parse::<f32>()
                                          .ok()
-                                         .map(|v| Duration::seconds((v * 1000.0) as i64))
+                                         .map(|v| Duration::milliseconds((v * 1000.0) as i64))
                 }
                 "duration" => result.duration = Some(Duration::seconds(try!(line.1.parse()))),
                 "bitrate" => result.bitrate = Some(try!(line.1.parse())),


### PR DESCRIPTION
The elapsed time duration is created with millisecond precision by
multiplying the second float value by 1000. Such value then has to be
fed into Duration::milliseconds rather than Duration::seconds to produce
a correctly scaled Duration instance.