### PR TITLE
Be principled about formatting commands.

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -152,7 +152,7 @@ impl ToQueueRangeOrPlace for RangeFrom<u32> {
 
 impl ToQueueRange for RangeFull {
     fn to_range(self) -> String {
-        String::new()
+        ToQueueRange::to_range(0..)
     }
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -70,20 +70,17 @@ impl Encodable for Status {
             e.emit_struct_field("song", 8, |e| self.song.encode(e))?;
             e.emit_struct_field("nextsong", 9, |e| self.nextsong.encode(e))?;
             e.emit_struct_field("time", 10, |e| {
-                    e.emit_option(|e| {
-                        match self.time {
-                            Some(p) => {
-                                e.emit_option_some(|e| {
-                                    e.emit_tuple(2, |e| {
-                                        e.emit_tuple_arg(0, |e| p.0.num_seconds().encode(e))?;
-                                        e.emit_tuple_arg(1, |e| p.1.num_seconds().encode(e))?;
-                                        Ok(())
-                                    })
+                    e.emit_option(|e| match self.time {
+                        Some(p) => {
+                            e.emit_option_some(|e| {
+                                e.emit_tuple(2, |e| {
+                                    e.emit_tuple_arg(0, |e| p.0.num_seconds().encode(e))?;
+                                    e.emit_tuple_arg(1, |e| p.1.num_seconds().encode(e))?;
+                                    Ok(())
                                 })
-                            }
-                            None => e.emit_option_none(),
-                        };
-                        Ok(())
+                            })
+                        }
+                        None => e.emit_option_none(),
                     })
                 })?;
             e.emit_struct_field("elapsed", 11, |e| {

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -2,8 +2,7 @@ extern crate mpd;
 
 mod helpers;
 use helpers::connect;
-use mpd::{Query, Term};
-use mpd::search::Window;
+use mpd::Query;
 
 #[test]
 fn search() {
@@ -13,18 +12,4 @@ fn search() {
     let songs = mpd.find(query, None);
     println!("{:?}", songs);
     assert!(songs.is_ok());
-}
-
-#[test]
-fn find_query_format() {
-    let mut query = Query::new();
-    let finished = query.and(Term::Tag("albumartist".into()), "Mac DeMarco")
-        .and(Term::Tag("album".into()), "Salad Days");
-    assert_eq!(&finished.to_string(), " albumartist \"Mac DeMarco\" album \"Salad Days\"");
-}
-
-#[test]
-fn find_window_format() {
-    let window: Window = (0, 2).into();
-    assert_eq!(&window.to_string(), " window 0:2");
 }


### PR DESCRIPTION
Rather than littering the code with calls so `format!`, pass all the command arguments as structured data, so there is one place where everything can be quoted.

Fixes #16.