### PR TITLE
Only warn on missing docs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 //! MPD client for Rust
 //!


### PR DESCRIPTION
Since we turn warnings into errors on travis, this should still catch mistakes, but make it easier to add test functionality before writing docs.