### PR TITLE
Add some more helpers for parsing responses.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -603,16 +603,8 @@ impl<S: Read + Write> Client<S> {
     /// List all stickers from a given object, identified by type and uri
     pub fn stickers(&mut self, typ: &str, uri: &str) -> Result<Vec<String>> {
         self.run_command("sticker list", (typ, uri))
-            .and_then(|_| {
-                self.read_pairs()
-                    .filter(|r| {
-                        r.as_ref()
-                            .map(|&(ref a, _)| *a == "sticker")
-                            .unwrap_or(true)
-                    })
-                    .map(|r| r.map(|(_, b)| b.splitn(2, '=').nth(1).map(|s| s.to_owned()).unwrap()))
-                    .collect()
-            })
+            .and_then(|_| self.read_list("sticker"))
+            .map(|v| v.into_iter().map(|b| b.splitn(2, '=').nth(1).map(|s| s.to_owned()).unwrap()).collect())
     }
 
     /// List all (file, sticker) pairs for sticker name and objects of given type

--- a/src/client.rs
+++ b/src/client.rs
@@ -482,61 +482,25 @@ impl<S: Read + Write> Client<S> {
     /// List all available commands
     pub fn commands(&mut self) -> Result<Vec<String>> {
         self.run_command("commands", ())
-            .and_then(|_| {
-                self.read_pairs()
-                    .filter(|r| {
-                        r.as_ref()
-                            .map(|&(ref a, _)| *a == "command")
-                            .unwrap_or(true)
-                    })
-                    .map(|r| r.map(|(_, b)| b))
-                    .collect()
-            })
+            .and_then(|_| self.read_list("command"))
     }
 
     /// List all forbidden commands
     pub fn notcommands(&mut self) -> Result<Vec<String>> {
         self.run_command("notcommands", ())
-            .and_then(|_| {
-                self.read_pairs()
-                    .filter(|r| {
-                        r.as_ref()
-                            .map(|&(ref a, _)| *a == "command")
-                            .unwrap_or(true)
-                    })
-                    .map(|r| r.map(|(_, b)| b))
-                    .collect()
-            })
+            .and_then(|_| self.read_list("command"))
     }
 
     /// List all available URL handlers
     pub fn urlhandlers(&mut self) -> Result<Vec<String>> {
         self.run_command("urlhandlers", ())
-            .and_then(|_| {
-                self.read_pairs()
-                    .filter(|r| {
-                        r.as_ref()
-                            .map(|&(ref a, _)| *a == "handler")
-                            .unwrap_or(true)
-                    })
-                    .map(|r| r.map(|(_, b)| b))
-                    .collect()
-            })
+            .and_then(|_| self.read_list("handler"))
     }
 
     /// List all supported tag types
     pub fn tagtypes(&mut self) -> Result<Vec<String>> {
         self.run_command("tagtypes", ())
-            .and_then(|_| {
-                self.read_pairs()
-                    .filter(|r| {
-                        r.as_ref()
-                            .map(|&(ref a, _)| *a == "tagtype")
-                            .unwrap_or(true)
-                    })
-                    .map(|r| r.map(|(_, b)| b))
-                    .collect()
-            })
+            .and_then(|_| self.read_list("tagtype"))
     }
 
     /// List all available decoder plugins
@@ -549,16 +513,8 @@ impl<S: Read + Write> Client<S> {
     /// List all channels available for current connection
     pub fn channels(&mut self) -> Result<Vec<Channel>> {
         self.run_command("channels", ())
-            .and_then(|_| {
-                self.read_pairs()
-                    .filter(|r| {
-                        r.as_ref()
-                            .map(|&(ref a, _)| *a == "channel")
-                            .unwrap_or(true)
-                    })
-                    .map(|r| r.map(|(_, b)| unsafe { Channel::new_unchecked(b) }))
-                    .collect()
-            })
+            .and_then(|_| self.read_list("channel"))
+            .map(|v| v.into_iter().map(|b| unsafe { Channel::new_unchecked(b) }).collect())
     }
 
     /// Read queued messages from subscribed channels
@@ -681,16 +637,7 @@ impl<S: Read + Write> Client<S> {
     /// with a tag set to given value
     pub fn find_sticker_eq(&mut self, typ: &str, uri: &str, name: &str, value: &str) -> Result<Vec<String>> {
         self.run_command("sticker find", (typ, uri, name, value))
-            .and_then(|_| {
-                self.read_pairs()
-                    .filter(|r| {
-                        r.as_ref()
-                            .map(|&(ref a, _)| *a == "file")
-                            .unwrap_or(true)
-                    })
-                    .map(|r| r.map(|(_, b)| b))
-                    .collect()
-            })
+            .and_then(|_| self.read_list("file"))
     }
     // }}}
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -221,7 +221,8 @@ impl<S: Read + Write> Client<S> {
     /// Get current playing song
     pub fn currentsong(&mut self) -> Result<Option<Song>> {
         self.run_command("currentsong", ())
-            .and_then(|_| self.read_struct::<Song>().map(|s| if s.place.is_none() { None } else { Some(s) }))
+            .and_then(|_| self.read_struct::<Song>())
+            .map(|s| if s.place.is_none() { None } else { Some(s) })
     }
 
     /// Clear current queue

--- a/src/client.rs
+++ b/src/client.rs
@@ -240,20 +240,13 @@ impl<S: Read + Write> Client<S> {
     pub fn push<P: AsRef<str>>(&mut self, path: P) -> Result<Id> {
         self.run_command("addid", path.as_ref())
             .and_then(|_| self.read_field("Id"))
-            .and_then(|v| {
-                self.expect_ok()
-                    .and_then(|_| v.parse().map_err(From::from).map(Id))
-            })
+            .map(Id)
     }
 
     /// Insert a song into a given position in a queue
     pub fn insert<P: AsRef<str>>(&mut self, path: P, pos: usize) -> Result<usize> {
         self.run_command("addid", (path.as_ref(), pos))
             .and_then(|_| self.read_field("Id"))
-            .and_then(|v| {
-                self.expect_ok()
-                    .and_then(|_| v.parse().map_err(From::from))
-            })
     }
 
     /// Delete a song (at some position) or several songs (in a range) from a queue
@@ -407,20 +400,12 @@ impl<S: Read + Write> Client<S> {
     pub fn rescan(&mut self) -> Result<u32> {
         self.run_command("rescan", ())
             .and_then(|_| self.read_field("updating_db"))
-            .and_then(|v| {
-                self.expect_ok()
-                    .and_then(|_| v.parse().map_err(From::from))
-            })
     }
 
     /// Run database update, i.e. remove non-existing files from DB
     pub fn update(&mut self) -> Result<u32> {
         self.run_command("update", ())
             .and_then(|_| self.read_field("updating_db"))
-            .and_then(|v| {
-                self.expect_ok()
-                    .and_then(|_| v.parse().map_err(From::from))
-            })
     }
     // }}}
 
@@ -492,7 +477,6 @@ impl<S: Read + Write> Client<S> {
     pub fn music_directory(&mut self) -> Result<String> {
         self.run_command("config", ())
             .and_then(|_| self.read_field("music_directory"))
-            .and_then(|d| self.expect_ok().map(|_| d))
     }
 
     /// List all available commands
@@ -665,7 +649,6 @@ impl<S: Read + Write> Client<S> {
     pub fn sticker(&mut self, typ: &str, uri: &str, name: &str) -> Result<String> {
         self.run_command("sticker set", (typ, uri, name))
             .and_then(|_| self.read_field("sticker"))
-            .and_then(|s| self.expect_ok().map(|_| s))
     }
 
     /// Set sticker value for a given object, identified by type and uri

--- a/src/client.rs
+++ b/src/client.rs
@@ -541,33 +541,7 @@ impl<S: Read + Write> Client<S> {
 
     /// List all available decoder plugins
     pub fn decoders(&mut self) -> Result<Vec<Plugin>> {
-        try!(self.run_command("decoders", ()));
-
-        let mut result = Vec::new();
-        let mut plugin: Option<Plugin> = None;
-        for reply in self.read_pairs() {
-            let (a, b) = try!(reply);
-            match &*a {
-                "plugin" => {
-                    plugin.map(|p| result.push(p));
-
-                    plugin = Some(Plugin {
-                        name: b,
-                        suffixes: Vec::new(),
-                        mime_types: Vec::new(),
-                    });
-                }
-                "mime_type" => {
-                    plugin.as_mut().map(|p| p.mime_types.push(b));
-                }
-                "suffix" => {
-                    plugin.as_mut().map(|p| p.suffixes.push(b));
-                }
-                _ => unreachable!(),
-            }
-        }
-        plugin.map(|p| result.push(p));
-        Ok(result)
+        self.run_command("decoders", ()).and_then(|_| self.read_struct())
     }
     // }}}
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -209,13 +209,13 @@ impl<S: Read + Write> Client<S> {
             "playlistinfo"
         };
         self.run_command(command, pos.to_range())
-            .and_then(|_| self.read_pairs().split("file").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("file"))
     }
 
     /// List all songs in a play queue
     pub fn queue(&mut self) -> Result<Vec<Song>> {
         self.run_command("playlistinfo", ())
-            .and_then(|_| self.read_pairs().split("file").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("file"))
     }
 
     /// Get current playing song
@@ -233,7 +233,7 @@ impl<S: Read + Write> Client<S> {
     /// List all changes in a queue since given version
     pub fn changes(&mut self, version: u32) -> Result<Vec<Song>> {
         self.run_command("plchanges", version)
-            .and_then(|_| self.read_pairs().split("file").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("file"))
     }
 
     /// Append a song into a queue
@@ -338,13 +338,13 @@ impl<S: Read + Write> Client<S> {
     /// List all playlists
     pub fn playlists(&mut self) -> Result<Vec<Playlist>> {
         self.run_command("listplaylists", ())
-            .and_then(|_| self.read_pairs().split("playlist").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("playlist"))
     }
 
     /// List all songs in a playlist
     pub fn playlist<N: ToPlaylistName>(&mut self, name: N) -> Result<Vec<Song>> {
         self.run_command("listplaylistinfo", name.to_name())
-            .and_then(|_| self.read_pairs().split("file").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("file"))
     }
 
     /// Load playlist into queue
@@ -447,12 +447,7 @@ impl<S: Read + Write> Client<S> {
 
     fn find_generic(&mut self, cmd: &str, query: &Query, window: Window) -> Result<Vec<Song>> {
         self.run_command(cmd, (query, window))
-            .and_then(|_| {
-                self.read_pairs()
-                    .split("file")
-                    .map(|v| v.and_then(FromMap::from_map))
-                    .collect()
-            })
+            .and_then(|_| self.read_structs("file"))
     }
 
     // }}}
@@ -461,7 +456,7 @@ impl<S: Read + Write> Client<S> {
     /// List all outputs
     pub fn outputs(&mut self) -> Result<Vec<Output>> {
         self.run_command("outputs", ())
-            .and_then(|_| self.read_pairs().split("outputid").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("outputid"))
     }
 
     /// Set given output enabled state
@@ -611,7 +606,7 @@ impl<S: Read + Write> Client<S> {
     /// Read queued messages from subscribed channels
     pub fn readmessages(&mut self) -> Result<Vec<Message>> {
         self.run_command("readmessages", ())
-            .and_then(|_| self.read_pairs().split("channel").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("channel"))
     }
 
     /// Send a message to a channel
@@ -639,13 +634,13 @@ impl<S: Read + Write> Client<S> {
     /// These mounts exist inside MPD process only, thus they can work without root permissions.
     pub fn mounts(&mut self) -> Result<Vec<Mount>> {
         self.run_command("listmounts", ())
-            .and_then(|_| self.read_pairs().split("mount").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("mount"))
     }
 
     /// List all network neighbors, which can be potentially mounted
     pub fn neighbors(&mut self) -> Result<Vec<Neighbor>> {
         self.run_command("listneighbors", ())
-            .and_then(|_| self.read_pairs().split("neighbor").map(|v| v.and_then(FromMap::from_map)).collect())
+            .and_then(|_| self.read_structs("neighbor"))
     }
 
     /// Mount given neighbor to a mount point

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ use std::io::Error as IoError;
 use std::num::{ParseFloatError, ParseIntError};
 use std::result;
 use std::str::FromStr;
+use std::string::ParseError as StringParseError;
 use time::ParseError as TimeParseError;
 
 // Server errors {{{
@@ -343,6 +344,12 @@ impl From<ParseIntError> for ParseError {
 impl From<ParseFloatError> for ParseError {
     fn from(e: ParseFloatError) -> ParseError {
         ParseError::BadFloat(e)
+    }
+}
+
+impl From<StringParseError> for ParseError {
+    fn from(e: StringParseError) -> ParseError {
+        match e {}
     }
 }
 // }}}

--- a/src/idle.rs
+++ b/src/idle.rs
@@ -125,14 +125,8 @@ impl<'a, S: 'a + Read + Write> IdleGuard<'a, S> {
     /// Get list of subsystems with new events, interrupting idle mode in process
     pub fn get(self) -> Result<Vec<Subsystem>, Error> {
         let result = self.0
-            .read_pairs()
-            .filter(|r| {
-                r.as_ref()
-                    .map(|&(ref a, _)| *a == "changed")
-                    .unwrap_or(true)
-            })
-            .map(|r| r.and_then(|(_, b)| b.parse().map_err(From::from)))
-            .collect();
+            .read_list("changed")
+            .and_then(|v| v.into_iter().map(|b| b.parse().map_err(From::from)).collect());
         forget(self);
         result
     }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,5 +1,8 @@
 //! The module defines decoder plugin data structures
 
+use convert::FromIter;
+use error::Error;
+
 /// Decoder plugin
 #[derive(Clone, Debug, PartialEq, RustcEncodable)]
 pub struct Plugin {
@@ -9,4 +12,34 @@ pub struct Plugin {
     pub suffixes: Vec<String>,
     /// supported MIME-types
     pub mime_types: Vec<String>,
+}
+
+impl FromIter for Vec<Plugin> {
+    fn from_iter<I: Iterator<Item = Result<(String, String), Error>>>(iter: I) -> Result<Self, Error> {
+        let mut result = Vec::new();
+        let mut plugin: Option<Plugin> = None;
+        for reply in iter {
+            let (a, b) = try!(reply);
+            match &*a {
+                "plugin" => {
+                    plugin.map(|p| result.push(p));
+
+                    plugin = Some(Plugin {
+                        name: b,
+                        suffixes: Vec::new(),
+                        mime_types: Vec::new(),
+                    });
+                }
+                "mime_type" => {
+                    plugin.as_mut().map(|p| p.mime_types.push(b));
+                }
+                "suffix" => {
+                    plugin.as_mut().map(|p| p.suffixes.push(b));
+                }
+                _ => unreachable!(),
+            }
+        }
+        plugin.map(|p| result.push(p));
+        Ok(result)
+    }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -111,6 +111,17 @@ pub trait Proto {
         self.read_pairs().split(key).map(|v| v.and_then(FromMap::from_map)).collect()
     }
 
+    fn read_list(&mut self, key: &'static str) -> Result<Vec<String>> {
+        self.read_pairs()
+            .filter(|r| {
+                r.as_ref()
+                    .map(|&(ref a, _)| *a == key)
+                    .unwrap_or(true)
+            })
+            .map(|r| r.map(|(_, b)| b))
+            .collect()
+    }
+
     fn read_struct<'a, T>(&'a mut self) -> Result<T>
         where T: 'a + FromIter,
               Self::Stream: 'a

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -2,7 +2,7 @@
 #![allow(missing_docs)]
 
 use bufstream::BufStream;
-use convert::FromIter;
+use convert::{FromIter, FromMap};
 use error::{Error, ProtoError, Result};
 
 use reply::Reply;
@@ -106,6 +106,12 @@ pub trait Proto {
 
     fn read_map(&mut self) -> Result<BTreeMap<String, String>> {
         self.read_pairs().collect()
+    }
+
+    fn read_structs<'a, T>(&'a mut self, key: &'static str) -> Result<Vec<T>>
+        where T: 'a + FromMap
+    {
+        self.read_pairs().split(key).map(|v| v.and_then(FromMap::from_map)).collect()
     }
 
     fn read_struct<'a, T>(&'a mut self) -> Result<T>

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -105,10 +105,6 @@ pub trait Proto {
 
     fn run_command<I>(&mut self, command: &str, arguments: I) -> Result<()> where I: ToArguments;
 
-    fn read_map(&mut self) -> Result<BTreeMap<String, String>> {
-        self.read_pairs().collect()
-    }
-
     fn read_structs<'a, T>(&'a mut self, key: &'static str) -> Result<Vec<T>>
         where T: 'a + FromMap
     {


### PR DESCRIPTION
I was playing around with porting to tokio, and having a bunch of parsing logic in `client` makes the porting harder.