### PR TITLE
Pin to a version of nightly that has a working rust-clippy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ addons:
       - binutils-dev
 rust:
   - stable
-  - nightly
+  - nightly-2017-02-05
 env:
   global:
     # override the default `--features unstable` used for the nightly branch
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
+    # Version of clippy known to work with pinned nightly.
+    - CLIPPY_VERSION=0.0.113
 before_script:
   - sudo apt-get update -qq
   - sudo apt-get install -y mpd
@@ -24,7 +26,7 @@ before_script:
   - export PATH=$HOME/.cargo/bin:$HOME/.local/bin:$PATH
   - |
     pip install 'travis-cargo<0.2' --user &&
-    travis-cargo --only nightly install -- --force clippy
+    travis-cargo --only nightly install -- --force clippy --vers CLIPPY_VERSION
   - |
     cargo install --force rustfmt
 script:


### PR DESCRIPTION
Also pin clippy version that is compatible with pinned nightly.