### PR TITLE
Parse duration as a float instead of integer. Fixes #27

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -66,9 +66,9 @@ impl<S: Read + Write> Client<S> {
         let version = try!(banner[7..].trim().parse::<Version>());
 
         Ok(Client {
-            socket: socket,
-            version: version,
-        })
+               socket: socket,
+               version: version,
+           })
     }
     // }}}
 
@@ -84,68 +84,57 @@ impl<S: Read + Write> Client<S> {
 
     /// Get MPD playing statistics
     pub fn stats(&mut self) -> Result<Stats> {
-        self.run_command("stats", ())
-            .and_then(|_| self.read_struct())
+        self.run_command("stats", ()).and_then(|_| self.read_struct())
     }
 
     /// Clear error state
     pub fn clearerror(&mut self) -> Result<()> {
-        self.run_command("clearerror", ())
-            .and_then(|_| self.expect_ok())
+        self.run_command("clearerror", ()).and_then(|_| self.expect_ok())
     }
 
     /// Set volume
     pub fn volume(&mut self, volume: i8) -> Result<()> {
-        self.run_command("setvol", volume)
-            .and_then(|_| self.expect_ok())
+        self.run_command("setvol", volume).and_then(|_| self.expect_ok())
     }
 
     /// Set repeat state
     pub fn repeat(&mut self, value: bool) -> Result<()> {
-        self.run_command("repeat", value as u8)
-            .and_then(|_| self.expect_ok())
+        self.run_command("repeat", value as u8).and_then(|_| self.expect_ok())
     }
 
     /// Set random state
     pub fn random(&mut self, value: bool) -> Result<()> {
-        self.run_command("random", value as u8)
-            .and_then(|_| self.expect_ok())
+        self.run_command("random", value as u8).and_then(|_| self.expect_ok())
     }
 
     /// Set single state
     pub fn single(&mut self, value: bool) -> Result<()> {
-        self.run_command("single", value as u8)
-            .and_then(|_| self.expect_ok())
+        self.run_command("single", value as u8).and_then(|_| self.expect_ok())
     }
 
     /// Set consume state
     pub fn consume(&mut self, value: bool) -> Result<()> {
-        self.run_command("consume", value as u8)
-            .and_then(|_| self.expect_ok())
+        self.run_command("consume", value as u8).and_then(|_| self.expect_ok())
     }
 
     /// Set crossfade time in seconds
     pub fn crossfade<T: ToSeconds>(&mut self, value: T) -> Result<()> {
-        self.run_command("crossfade", value.to_seconds())
-            .and_then(|_| self.expect_ok())
+        self.run_command("crossfade", value.to_seconds()).and_then(|_| self.expect_ok())
     }
 
     /// Set mixramp level in dB
     pub fn mixrampdb(&mut self, value: f32) -> Result<()> {
-        self.run_command("mixrampdb", value)
-            .and_then(|_| self.expect_ok())
+        self.run_command("mixrampdb", value).and_then(|_| self.expect_ok())
     }
 
     /// Set mixramp delay in seconds
     pub fn mixrampdelay<T: ToSeconds>(&mut self, value: T) -> Result<()> {
-        self.run_command("mixrampdelay", value.to_seconds())
-            .and_then(|_| self.expect_ok())
+        self.run_command("mixrampdelay", value.to_seconds()).and_then(|_| self.expect_ok())
     }
 
     /// Set replay gain mode
     pub fn replaygain(&mut self, gain: ReplayGain) -> Result<()> {
-        self.run_command("replay_gain_mode", gain)
-            .and_then(|_| self.expect_ok())
+        self.run_command("replay_gain_mode", gain).and_then(|_| self.expect_ok())
     }
     // }}}
 
@@ -158,46 +147,39 @@ impl<S: Read + Write> Client<S> {
     /// Start playback from given song in a queue
     pub fn switch<T: ToQueuePlace>(&mut self, place: T) -> Result<()> {
         let command = if T::is_id() { "playid" } else { "play" };
-        self.run_command(command, place.to_place())
-            .and_then(|_| self.expect_ok())
+        self.run_command(command, place.to_place()).and_then(|_| self.expect_ok())
     }
 
     /// Switch to a next song in queue
     #[cfg_attr(feature = "cargo-clippy", allow(should_implement_trait))]
     pub fn next(&mut self) -> Result<()> {
-        self.run_command("next", ())
-            .and_then(|_| self.expect_ok())
+        self.run_command("next", ()).and_then(|_| self.expect_ok())
     }
 
     /// Switch to a previous song in queue
     pub fn prev(&mut self) -> Result<()> {
-        self.run_command("previous", ())
-            .and_then(|_| self.expect_ok())
+        self.run_command("previous", ()).and_then(|_| self.expect_ok())
     }
 
     /// Stop playback
     pub fn stop(&mut self) -> Result<()> {
-        self.run_command("stop", ())
-            .and_then(|_| self.expect_ok())
+        self.run_command("stop", ()).and_then(|_| self.expect_ok())
     }
 
     /// Set pause state
     pub fn pause(&mut self, value: bool) -> Result<()> {
-        self.run_command("pause", value as u8)
-            .and_then(|_| self.expect_ok())
+        self.run_command("pause", value as u8).and_then(|_| self.expect_ok())
     }
 
     /// Seek to a given place (in seconds) in a given song
     pub fn seek<T: ToSeconds, P: ToQueuePlace>(&mut self, place: P, pos: T) -> Result<()> {
         let command = if P::is_id() { "seekid" } else { "seek" };
-        self.run_command(command, (place.to_place(), pos.to_seconds()))
-            .and_then(|_| self.expect_ok())
+        self.run_command(command, (place.to_place(), pos.to_seconds())).and_then(|_| self.expect_ok())
     }
 
     /// Seek to a given place (in seconds) in the current song
     pub fn rewind<T: ToSeconds>(&mut self, pos: T) -> Result<()> {
-        self.run_command("seekcur", pos.to_seconds())
-            .and_then(|_| self.expect_ok())
+        self.run_command("seekcur", pos.to_seconds()).and_then(|_| self.expect_ok())
     }
     // }}}
 
@@ -209,100 +191,83 @@ impl<S: Read + Write> Client<S> {
         } else {
             "playlistinfo"
         };
-        self.run_command(command, pos.to_range())
-            .and_then(|_| self.read_structs("file"))
+        self.run_command(command, pos.to_range()).and_then(|_| self.read_structs("file"))
     }
 
     /// List all songs in a play queue
     pub fn queue(&mut self) -> Result<Vec<Song>> {
-        self.run_command("playlistinfo", ())
-            .and_then(|_| self.read_structs("file"))
+        self.run_command("playlistinfo", ()).and_then(|_| self.read_structs("file"))
     }
 
     /// Get current playing song
     pub fn currentsong(&mut self) -> Result<Option<Song>> {
-        self.run_command("currentsong", ())
-            .and_then(|_| self.read_struct::<Song>())
-            .map(|s| if s.place.is_none() { None } else { Some(s) })
+        self.run_command("currentsong", ()).and_then(|_| self.read_struct::<Song>()).map(|s| if s.place.is_none() { None } else { Some(s) })
     }
 
     /// Clear current queue
     pub fn clear(&mut self) -> Result<()> {
-        self.run_command("clear", ())
-            .and_then(|_| self.expect_ok())
+        self.run_command("clear", ()).and_then(|_| self.expect_ok())
     }
 
     /// List all changes in a queue since given version
     pub fn changes(&mut self, version: u32) -> Result<Vec<Song>> {
-        self.run_command("plchanges", version)
-            .and_then(|_| self.read_structs("file"))
+        self.run_command("plchanges", version).and_then(|_| self.read_structs("file"))
     }
 
     /// Append a song into a queue
     pub fn push<P: ToSongPath>(&mut self, path: P) -> Result<Id> {
-        self.run_command("addid", path)
-            .and_then(|_| self.read_field("Id"))
-            .map(Id)
+        self.run_command("addid", path).and_then(|_| self.read_field("Id")).map(Id)
     }
 
     /// Insert a song into a given position in a queue
     pub fn insert<P: ToSongPath>(&mut self, path: P, pos: usize) -> Result<usize> {
-        self.run_command("addid", (path, pos))
-            .and_then(|_| self.read_field("Id"))
+        self.run_command("addid", (path, pos)).and_then(|_| self.read_field("Id"))
     }
 
     /// Delete a song (at some position) or several songs (in a range) from a queue
     pub fn delete<T: ToQueueRangeOrPlace>(&mut self, pos: T) -> Result<()> {
         let command = if T::is_id() { "deleteid" } else { "delete" };
-        self.run_command(command, pos.to_range())
-            .and_then(|_| self.expect_ok())
+        self.run_command(command, pos.to_range()).and_then(|_| self.expect_ok())
     }
 
     /// Move a song (at a some position) or several songs (in a range) to other position in queue
     pub fn shift<T: ToQueueRangeOrPlace>(&mut self, from: T, to: usize) -> Result<()> {
         let command = if T::is_id() { "moveid" } else { "move" };
-        self.run_command(command, (from.to_range(), to))
-            .and_then(|_| self.expect_ok())
+        self.run_command(command, (from.to_range(), to)).and_then(|_| self.expect_ok())
     }
 
     /// Swap to songs in a queue
     pub fn swap<T: ToQueuePlace>(&mut self, one: T, two: T) -> Result<()> {
         let command = if T::is_id() { "swapid" } else { "swap" };
-        self.run_command(command, (one.to_place(), two.to_place()))
-            .and_then(|_| self.expect_ok())
+        self.run_command(command, (one.to_place(), two.to_place())).and_then(|_| self.expect_ok())
     }
 
     /// Shuffle queue in a given range (use `..` to shuffle full queue)
     pub fn shuffle<T: ToQueueRange>(&mut self, range: T) -> Result<()> {
-        self.run_command("shuffle", range.to_range())
-            .and_then(|_| self.expect_ok())
+        self.run_command("shuffle", range.to_range()).and_then(|_| self.expect_ok())
     }
 
     /// Set song priority in a queue
     pub fn priority<T: ToQueueRangeOrPlace>(&mut self, pos: T, prio: u8) -> Result<()> {
         let command = if T::is_id() { "prioid" } else { "prio" };
-        self.run_command(command, (prio, pos.to_range()))
-            .and_then(|_| self.expect_ok())
+        self.run_command(command, (prio, pos.to_range())).and_then(|_| self.expect_ok())
     }
 
     /// Set song range (in seconds) to play
     ///
     /// Doesn't work for currently playing song.
     pub fn range<T: ToSongId, R: ToSongRange>(&mut self, song: T, range: R) -> Result<()> {
-        self.run_command("rangeid", (song.to_song_id(), range.to_range()))
-            .and_then(|_| self.expect_ok())
+        self.run_command("rangeid", (song.to_song_id(), range.to_range())).and_then(|_| self.expect_ok())
     }
 
     /// Add tag to a song
     pub fn tag<T: ToSongId>(&mut self, song: T, tag: &str, value: &str) -> Result<()> {
-        self.run_command("addtagid", (song.to_song_id(), tag, value))
-            .and_then(|_| self.expect_ok())
+        self.run_command("addtagid", (song.to_song_id(), tag, value)).and_then(|_| self.expect_ok())
     }
 
     /// Delete tag from a song
     pub fn untag<T: ToSongId>(&mut self, song: T, tag: &str) -> Result<()> {
-        self.run_command("cleartagid", (song.to_song_id(), tag))
-            .and_then(|_| self.expect_ok())
+        self.run_command("cleartagid", (song.to_song_id(), tag)).and_then(|_| self.expect_ok())
     }
     // }}}
 
@@ -324,22 +289,19 @@ impl<S: Read + Write> Client<S> {
 
     /// Login to MPD server with given password
     pub fn login(&mut self, password: &str) -> Result<()> {
-        self.run_command("password", password)
-            .and_then(|_| self.expect_ok())
+        self.run_command("password", password).and_then(|_| self.expect_ok())
     }
     // }}}
 
     // Playlist methods {{{
     /// List all playlists
     pub fn playlists(&mut self) -> Result<Vec<Playlist>> {
-        self.run_command("listplaylists", ())
-            .and_then(|_| self.read_structs("playlist"))
+        self.run_command("listplaylists", ()).and_then(|_| self.read_structs("playlist"))
     }
 
     /// List all songs in a playlist
     pub fn playlist<N: ToPlaylistName>(&mut self, name: N) -> Result<Vec<Song>> {
-        self.run_command("listplaylistinfo", name.to_name())
-            .and_then(|_| self.read_structs("file"))
+        self.run_command("listplaylistinfo", name.to_name()).and_then(|_| self.read_structs("file"))
     }
 
     /// Load playlist into queue
@@ -347,52 +309,44 @@ impl<S: Read + Write> Client<S> {
     /// You can give either full range (`..`) to load all songs in a playlist,
     /// or some partial range to load only part of playlist.
     pub fn load<T: ToQueueRange, N: ToPlaylistName>(&mut self, name: N, range: T) -> Result<()> {
-        self.run_command("load", (name.to_name(), range.to_range()))
-            .and_then(|_| self.expect_ok())
+        self.run_command("load", (name.to_name(), range.to_range())).and_then(|_| self.expect_ok())
     }
 
     /// Save current queue into playlist
     ///
     /// If playlist with given name doesn't exist, create new one.
     pub fn save<N: ToPlaylistName>(&mut self, name: N) -> Result<()> {
-        self.run_command("save", name.to_name())
-            .and_then(|_| self.expect_ok())
+        self.run_command("save", name.to_name()).and_then(|_| self.expect_ok())
     }
 
     /// Rename playlist
     pub fn pl_rename<N: ToPlaylistName>(&mut self, name: N, newname: &str) -> Result<()> {
-        self.run_command("rename", (name.to_name(), newname))
-            .and_then(|_| self.expect_ok())
+        self.run_command("rename", (name.to_name(), newname)).and_then(|_| self.expect_ok())
     }
 
     /// Clear playlist
     pub fn pl_clear<N: ToPlaylistName>(&mut self, name: N) -> Result<()> {
-        self.run_command("playlistclear", name.to_name())
-            .and_then(|_| self.expect_ok())
+        self.run_command("playlistclear", name.to_name()).and_then(|_| self.expect_ok())
     }
 
     /// Delete playlist
     pub fn pl_remove<N: ToPlaylistName>(&mut self, name: N) -> Result<()> {
-        self.run_command("rm", name.to_name())
-            .and_then(|_| self.expect_ok())
+        self.run_command("rm", name.to_name()).and_then(|_| self.expect_ok())
     }
 
     /// Add new songs to a playlist
     pub fn pl_push<N: ToPlaylistName, P: ToSongPath>(&mut self, name: N, path: P) -> Result<()> {
-        self.run_command("playlistadd", (name.to_name(), path))
-            .and_then(|_| self.expect_ok())
+        self.run_command("playlistadd", (name.to_name(), path)).and_then(|_| self.expect_ok())
     }
 
     /// Delete a song at a given position in a playlist
     pub fn pl_delete<N: ToPlaylistName>(&mut self, name: N, pos: u32) -> Result<()> {
-        self.run_command("playlistdelete", (name.to_name(), pos))
-            .and_then(|_| self.expect_ok())
+        self.run_command("playlistdelete", (name.to_name(), pos)).and_then(|_| self.expect_ok())
     }
 
     /// Move song in a playlist from one position into another
     pub fn pl_shift<N: ToPlaylistName>(&mut self, name: N, from: u32, to: u32) -> Result<()> {
-        self.run_command("playlistmove", (name.to_name(), from, to))
-            .and_then(|_| self.expect_ok())
+        self.run_command("playlistmove", (name.to_name(), from, to)).and_then(|_| self.expect_ok())
     }
     // }}}
 
@@ -400,14 +354,12 @@ impl<S: Read + Write> Client<S> {
     /// Run database rescan, i.e. remove non-existing files from DB
     /// as well as add new files to DB
     pub fn rescan(&mut self) -> Result<u32> {
-        self.run_command("rescan", ())
-            .and_then(|_| self.read_field("updating_db"))
+        self.run_command("rescan", ()).and_then(|_| self.read_field("updating_db"))
     }
 
     /// Run database update, i.e. remove non-existing files from DB
     pub fn update(&mut self) -> Result<u32> {
-        self.run_command("update", ())
-            .and_then(|_| self.read_field("updating_db"))
+        self.run_command("update", ()).and_then(|_| self.read_field("updating_db"))
     }
     // }}}
 
@@ -433,28 +385,24 @@ impl<S: Read + Write> Client<S> {
     }
 
     fn find_generic(&mut self, cmd: &str, query: &Query, window: Window) -> Result<Vec<Song>> {
-        self.run_command(cmd, (query, window))
-            .and_then(|_| self.read_structs("file"))
+        self.run_command(cmd, (query, window)).and_then(|_| self.read_structs("file"))
     }
 
     /// Lists unique tags values of the specified type for songs matching the given query.
     // TODO: list type [filtertype] [filterwhat] [...] [group] [grouptype] [...]
     // It isn't clear if or how `group` works
     pub fn list(&mut self, term: &Term, query: &Query) -> Result<Vec<String>> {
-        self.run_command("list", (term, query))
-            .and_then(|_| self.read_pairs().map(|p| p.map(|p| p.1)).collect())
+        self.run_command("list", (term, query)).and_then(|_| self.read_pairs().map(|p| p.map(|p| p.1)).collect())
     }
 
     /// Find all songs in the db that match query and adds them to current playlist.
     pub fn findadd(&mut self, query: &Query) -> Result<()> {
-        self.run_command("findadd", query)
-            .and_then(|_| self.expect_ok())
+        self.run_command("findadd", query).and_then(|_| self.expect_ok())
     }
 
     /// Lists the contents of a directory.
     pub fn lsinfo<P: ToSongPath>(&mut self, path: P) -> Result<Song> {
-        self.run_command("lsinfo", path)
-            .and_then(|_| self.read_struct())
+        self.run_command("lsinfo", path).and_then(|_| self.read_struct())
     }
 
     // }}}
@@ -462,8 +410,7 @@ impl<S: Read + Write> Client<S> {
     // Output methods {{{
     /// List all outputs
     pub fn outputs(&mut self) -> Result<Vec<Output>> {
-        self.run_command("outputs", ())
-            .and_then(|_| self.read_structs("outputid"))
+        self.run_command("outputs", ()).and_then(|_| self.read_structs("outputid"))
     }
 
     /// Set given output enabled state
@@ -477,52 +424,44 @@ impl<S: Read + Write> Client<S> {
 
     /// Disable given output
     pub fn out_disable<T: ToOutputId>(&mut self, id: T) -> Result<()> {
-        self.run_command("disableoutput", id.to_output_id())
-            .and_then(|_| self.expect_ok())
+        self.run_command("disableoutput", id.to_output_id()).and_then(|_| self.expect_ok())
     }
 
     /// Enable given output
     pub fn out_enable<T: ToOutputId>(&mut self, id: T) -> Result<()> {
-        self.run_command("enableoutput", id.to_output_id())
-            .and_then(|_| self.expect_ok())
+        self.run_command("enableoutput", id.to_output_id()).and_then(|_| self.expect_ok())
     }
 
     /// Toggle given output
     pub fn out_toggle<T: ToOutputId>(&mut self, id: T) -> Result<()> {
-        self.run_command("toggleoutput", id.to_output_id())
-            .and_then(|_| self.expect_ok())
+        self.run_command("toggleoutput", id.to_output_id()).and_then(|_| self.expect_ok())
     }
     // }}}
 
     // Reflection methods {{{
     /// Get current music directory
     pub fn music_directory(&mut self) -> Result<String> {
-        self.run_command("config", ())
-            .and_then(|_| self.read_field("music_directory"))
+        self.run_command("config", ()).and_then(|_| self.read_field("music_directory"))
     }
 
     /// List all available commands
     pub fn commands(&mut self) -> Result<Vec<String>> {
-        self.run_command("commands", ())
-            .and_then(|_| self.read_list("command"))
+        self.run_command("commands", ()).and_then(|_| self.read_list("command"))
     }
 
     /// List all forbidden commands
     pub fn notcommands(&mut self) -> Result<Vec<String>> {
-        self.run_command("notcommands", ())
-            .and_then(|_| self.read_list("command"))
+        self.run_command("notcommands", ()).and_then(|_| self.read_list("command"))
     }
 
     /// List all available URL handlers
     pub fn urlhandlers(&mut self) -> Result<Vec<String>> {
-        self.run_command("urlhandlers", ())
-            .and_then(|_| self.read_list("handler"))
+        self.run_command("urlhandlers", ()).and_then(|_| self.read_list("handler"))
     }
 
     /// List all supported tag types
     pub fn tagtypes(&mut self) -> Result<Vec<String>> {
-        self.run_command("tagtypes", ())
-            .and_then(|_| self.read_list("tagtype"))
+        self.run_command("tagtypes", ()).and_then(|_| self.read_list("tagtype"))
     }
 
     /// List all available decoder plugins
@@ -534,33 +473,29 @@ impl<S: Read + Write> Client<S> {
     // Messaging {{{
     /// List all channels available for current connection
     pub fn channels(&mut self) -> Result<Vec<Channel>> {
-        self.run_command("channels", ())
-            .and_then(|_| self.read_list("channel"))
-            .map(|v| v.into_iter().map(|b| unsafe { Channel::new_unchecked(b) }).collect())
+        self.run_command("channels", ()).and_then(|_| self.read_list("channel")).map(|v| {
+            v.into_iter().map(|b| unsafe { Channel::new_unchecked(b) }).collect()
+        })
     }
 
     /// Read queued messages from subscribed channels
     pub fn readmessages(&mut self) -> Result<Vec<Message>> {
-        self.run_command("readmessages", ())
-            .and_then(|_| self.read_structs("channel"))
+        self.run_command("readmessages", ()).and_then(|_| self.read_structs("channel"))
     }
 
     /// Send a message to a channel
     pub fn sendmessage(&mut self, channel: Channel, message: &str) -> Result<()> {
-        self.run_command("sendmessage", (channel, message))
-            .and_then(|_| self.expect_ok())
+        self.run_command("sendmessage", (channel, message)).and_then(|_| self.expect_ok())
     }
 
     /// Subscribe to a channel
     pub fn subscribe(&mut self, channel: Channel) -> Result<()> {
-        self.run_command("subscribe", channel)
-            .and_then(|_| self.expect_ok())
+        self.run_command("subscribe", channel).and_then(|_| self.expect_ok())
     }
 
     /// Unsubscribe to a channel
     pub fn unsubscribe(&mut self, channel: Channel) -> Result<()> {
-        self.run_command("unsubscribe", channel)
-            .and_then(|_| self.expect_ok())
+        self.run_command("unsubscribe", channel).and_then(|_| self.expect_ok())
     }
     // }}}
 
@@ -569,30 +504,26 @@ impl<S: Read + Write> Client<S> {
     ///
     /// These mounts exist inside MPD process only, thus they can work without root permissions.
     pub fn mounts(&mut self) -> Result<Vec<Mount>> {
-        self.run_command("listmounts", ())
-            .and_then(|_| self.read_structs("mount"))
+        self.run_command("listmounts", ()).and_then(|_| self.read_structs("mount"))
     }
 
     /// List all network neighbors, which can be potentially mounted
     pub fn neighbors(&mut self) -> Result<Vec<Neighbor>> {
-        self.run_command("listneighbors", ())
-            .and_then(|_| self.read_structs("neighbor"))
+        self.run_command("listneighbors", ()).and_then(|_| self.read_structs("neighbor"))
     }
 
     /// Mount given neighbor to a mount point
     ///
     /// The mount exists inside MPD process only, thus it can work without root permissions.
     pub fn mount(&mut self, path: &str, uri: &str) -> Result<()> {
-        self.run_command("mount", (path, uri))
-            .and_then(|_| self.expect_ok())
+        self.run_command("mount", (path, uri)).and_then(|_| self.expect_ok())
     }
 
     /// Unmount given active (virtual) mount
     ///
     /// The mount exists inside MPD process only, thus it can work without root permissions.
     pub fn unmount(&mut self, path: &str) -> Result<()> {
-        self.run_command("unmount", path)
-            .and_then(|_| self.expect_ok())
+        self.run_command("unmount", path).and_then(|_| self.expect_ok())
     }
     // }}}
 
@@ -607,53 +538,53 @@ impl<S: Read + Write> Client<S> {
 
     /// Set sticker value for a given object, identified by type and uri
     pub fn set_sticker(&mut self, typ: &str, uri: &str, name: &str, value: &str) -> Result<()> {
-        self.run_command("sticker set", (typ, uri, name, value))
-            .and_then(|_| self.expect_ok())
+        self.run_command("sticker set", (typ, uri, name, value)).and_then(|_| self.expect_ok())
     }
 
     /// Delete sticker from a given object, identified by type and uri
     pub fn delete_sticker(&mut self, typ: &str, uri: &str, name: &str) -> Result<()> {
-        self.run_command("sticker delete", (typ, uri, name))
-            .and_then(|_| self.expect_ok())
+        self.run_command("sticker delete", (typ, uri, name)).and_then(|_| self.expect_ok())
     }
 
     /// Remove all stickers from a given object, identified by type and uri
     pub fn clear_stickers(&mut self, typ: &str, uri: &str) -> Result<()> {
-        self.run_command("sticker delete", (typ, uri))
-            .and_then(|_| self.expect_ok())
+        self.run_command("sticker delete", (typ, uri)).and_then(|_| self.expect_ok())
     }
 
     /// List all stickers from a given object, identified by type and uri
     pub fn stickers(&mut self, typ: &str, uri: &str) -> Result<Vec<String>> {
-        self.run_command("sticker list", (typ, uri))
-            .and_then(|_| self.read_list("sticker"))
-            .map(|v| v.into_iter().map(|b| b.splitn(2, '=').nth(1).map(|s| s.to_owned()).unwrap()).collect())
+        self.run_command("sticker list", (typ, uri)).and_then(|_| self.read_list("sticker")).map(|v| {
+            v.into_iter()
+                .map(|b| {
+                         b.splitn(2, '=')
+                             .nth(1)
+                             .map(|s| s.to_owned())
+                             .unwrap()
+                     })
+                .collect()
+        })
     }
 
     /// List all (file, sticker) pairs for sticker name and objects of given type
     /// from given directory (identified by uri)
     pub fn find_sticker(&mut self, typ: &str, uri: &str, name: &str) -> Result<Vec<(String, String)>> {
-        self.run_command("sticker find", (typ, uri, name))
-            .and_then(|_| {
-                self.read_pairs()
-                    .split("file")
-                    .map(|rmap| {
-                        rmap.map(|mut map| {
-                            (map.remove("file").unwrap(),
-                             map.remove("sticker")
-                                 .and_then(|s| s.splitn(2, '=').nth(1).map(|s| s.to_owned()))
-                                 .unwrap())
-                        })
-                    })
-                    .collect()
-            })
+        self.run_command("sticker find", (typ, uri, name)).and_then(|_| {
+            self.read_pairs()
+                .split("file")
+                .map(|rmap| {
+                         rmap.map(|mut map| {
+                                      (map.remove("file").unwrap(),
+                                       map.remove("sticker").and_then(|s| s.splitn(2, '=').nth(1).map(|s| s.to_owned())).unwrap())
+                                  })
+                     })
+                .collect()
+        })
     }
 
     /// List all files of a given type under given directory (identified by uri)
     /// with a tag set to given value
     pub fn find_sticker_eq(&mut self, typ: &str, uri: &str, name: &str, value: &str) -> Result<Vec<String>> {
-        self.run_command("sticker find", (typ, uri, name, value))
-            .and_then(|_| self.read_list("file"))
+        self.run_command("sticker find", (typ, uri, name, value)).and_then(|_| self.read_list("file"))
     }
     // }}}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,11 +142,11 @@ impl FromStr for ServerError {
                             let command = s[left_brace + 1..right_brace].to_string();
                             let detail = s[right_brace + 1..].trim().to_string();
                             Ok(ServerError {
-                                code: code,
-                                pos: pos,
-                                command: command,
-                                detail: detail,
-                            })
+                                   code: code,
+                                   pos: pos,
+                                   command: command,
+                                   detail: detail,
+                               })
                         } else {
                             Err(ParseError::NoMessage)
                         }

--- a/src/idle.rs
+++ b/src/idle.rs
@@ -124,9 +124,7 @@ pub struct IdleGuard<'a, S: 'a + Read + Write>(&'a mut Client<S>);
 impl<'a, S: 'a + Read + Write> IdleGuard<'a, S> {
     /// Get list of subsystems with new events, interrupting idle mode in process
     pub fn get(self) -> Result<Vec<Subsystem>, Error> {
-        let result = self.0
-            .read_list("changed")
-            .and_then(|v| v.into_iter().map(|b| b.parse().map_err(From::from)).collect());
+        let result = self.0.read_list("changed").and_then(|v| v.into_iter().map(|b| b.parse().map_err(From::from)).collect());
         forget(self);
         result
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -27,13 +27,9 @@ pub struct Message {
 impl FromMap for Message {
     fn from_map(map: BTreeMap<String, String>) -> Result<Message, Error> {
         Ok(Message {
-            channel: Channel(try!(map.get("channel")
-                .map(|v| v.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("channel"))))),
-            message: try!(map.get("message")
-                .map(|v| v.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("message")))),
-        })
+               channel: Channel(try!(map.get("channel").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("channel"))))),
+               message: try!(map.get("message").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("message")))),
+           })
     }
 }
 
@@ -70,8 +66,8 @@ impl Channel {
     /// numbers (`0`-`9`), underscore, forward slash, dot and colon (`_`, `/`, `.`, `:`)
     pub fn is_valid_name(name: &str) -> bool {
         name.bytes().all(|b| {
-            (0x61 <= b && b <= 0x7a) || (0x41 <= b && b <= 0x5a) || (0x30 <= b && b <= 0x39) ||
-            (b == 0x5f || b == 0x2f || b == 0x2e || b == 0x3a)
-        })
+                             (0x61 <= b && b <= 0x7a) || (0x41 <= b && b <= 0x5a) || (0x30 <= b && b <= 0x39) ||
+                             (b == 0x5f || b == 0x2f || b == 0x2e || b == 0x3a)
+                         })
     }
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -26,13 +26,9 @@ pub struct Mount {
 impl FromMap for Mount {
     fn from_map(map: BTreeMap<String, String>) -> Result<Mount, Error> {
         Ok(Mount {
-            name: try!(map.get("mount")
-                .map(|s| s.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("mount")))),
-            storage: try!(map.get("storage")
-                .map(|s| s.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("storage")))),
-        })
+               name: try!(map.get("mount").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("mount")))),
+               storage: try!(map.get("storage").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("storage")))),
+           })
     }
 }
 
@@ -48,12 +44,8 @@ pub struct Neighbor {
 impl FromMap for Neighbor {
     fn from_map(map: BTreeMap<String, String>) -> Result<Neighbor, Error> {
         Ok(Neighbor {
-            name: try!(map.get("name")
-                .map(|s| s.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("name")))),
-            storage: try!(map.get("neighbor")
-                .map(|s| s.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("neighbor")))),
-        })
+               name: try!(map.get("name").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("name")))),
+               storage: try!(map.get("neighbor").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("neighbor")))),
+           })
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -20,11 +20,9 @@ pub struct Output {
 impl FromMap for Output {
     fn from_map(map: BTreeMap<String, String>) -> Result<Output, Error> {
         Ok(Output {
-            id: get_field!(map, "outputid"),
-            name: try!(map.get("outputname")
-                .map(|v| v.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("outputname")))),
-            enabled: get_field!(map, bool "outputenabled"),
-        })
+               id: get_field!(map, "outputid"),
+               name: try!(map.get("outputname").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("outputname")))),
+               enabled: get_field!(map, bool "outputenabled"),
+           })
     }
 }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -18,12 +18,10 @@ pub struct Playlist {
 impl FromMap for Playlist {
     fn from_map(map: BTreeMap<String, String>) -> Result<Playlist, Error> {
         Ok(Playlist {
-            name: try!(map.get("playlist")
-                .map(|v| v.to_owned())
-                .ok_or(Error::Proto(ProtoError::NoField("playlist")))),
-            last_mod: try!(map.get("Last-Modified")
+               name: try!(map.get("playlist").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("playlist")))),
+               last_mod: try!(map.get("Last-Modified")
                 .ok_or(Error::Proto(ProtoError::NoField("Last-Modified")))
                 .and_then(|v| strptime(&*v, "%Y-%m-%dT%H:%M:%S%Z").map_err(From::from))),
-        })
+           })
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -25,10 +25,10 @@ impl FromIter for Vec<Plugin> {
                     plugin.map(|p| result.push(p));
 
                     plugin = Some(Plugin {
-                        name: b,
-                        suffixes: Vec::new(),
-                        mime_types: Vec::new(),
-                    });
+                                      name: b,
+                                      suffixes: Vec::new(),
+                                      mime_types: Vec::new(),
+                                  });
                 }
                 "mime_type" => {
                     plugin.as_mut().map(|p| p.mime_types.push(b));

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -19,9 +19,8 @@ impl<I> Iterator for Pairs<I>
 {
     type Item = Result<(String, String)>;
     fn next(&mut self) -> Option<Result<(String, String)>> {
-        let reply: Option<Result<Reply>> = self.0
-            .next()
-            .map(|v| v.map_err(Error::Io).and_then(|s| s.parse::<Reply>().map_err(Error::Parse)));
+        let reply: Option<Result<Reply>> =
+            self.0.next().map(|v| v.map_err(Error::Io).and_then(|s| s.parse::<Reply>().map_err(Error::Parse)));
         match reply {
             Some(Ok(Reply::Pair(a, b))) => Some(Ok((a, b))),
             None |
@@ -108,16 +107,15 @@ pub trait Proto {
     fn read_structs<'a, T>(&'a mut self, key: &'static str) -> Result<Vec<T>>
         where T: 'a + FromMap
     {
-        self.read_pairs().split(key).map(|v| v.and_then(FromMap::from_map)).collect()
+        self.read_pairs()
+            .split(key)
+            .map(|v| v.and_then(FromMap::from_map))
+            .collect()
     }
 
     fn read_list(&mut self, key: &'static str) -> Result<Vec<String>> {
         self.read_pairs()
-            .filter(|r| {
-                r.as_ref()
-                    .map(|&(ref a, _)| *a == key)
-                    .unwrap_or(true)
-            })
+            .filter(|r| r.as_ref().map(|&(ref a, _)| *a == key).unwrap_or(true))
             .map(|r| r.map(|(_, b)| b))
             .collect()
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -64,12 +64,12 @@ impl<'a> Query<'a> {
 impl<'a> fmt::Display for Term<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(match *self {
-            Term::Any => "any",
-            Term::File => "file",
-            Term::Base => "base",
-            Term::LastMod => "modified-since",
-            Term::Tag(ref tag) => &*tag,
-        })
+                        Term::Any => "any",
+                        Term::File => "file",
+                        Term::Base => "base",
+                        Term::LastMod => "modified-since",
+                        Term::Tag(ref tag) => &*tag,
+                    })
     }
 }
 
@@ -134,8 +134,7 @@ mod test {
     #[test]
     fn find_query_format() {
         let mut query = Query::new();
-        let finished = query.and(Term::Tag("albumartist".into()), "Mac DeMarco")
-            .and(Term::Tag("album".into()), "Salad Days");
+        let finished = query.and(Term::Tag("albumartist".into()), "Mac DeMarco").and(Term::Tag("album".into()), "Salad Days");
         let output = collect(&*finished);
         assert_eq!(output, vec!["albumartist", "Mac DeMarco", "album", "Salad Days"]);
     }

--- a/src/song.rs
+++ b/src/song.rs
@@ -53,9 +53,9 @@ impl Encodable for Range {
             e.emit_tuple_arg(0, |e| e.emit_i64(self.0.num_seconds()))?;
             e.emit_tuple_arg(1, |e| {
                 e.emit_option(|e| match self.1 {
-                    Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
-                    None => e.emit_option_none(),
-                })
+                                  Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                  None => e.emit_option_none(),
+                              })
             })
         })
     }
@@ -69,7 +69,9 @@ impl Default for Range {
 
 impl fmt::Display for Range {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.num_seconds().fmt(f)?;
+        self.0
+            .num_seconds()
+            .fmt(f)?;
         f.write_str(":")?;
         if let Some(v) = self.1 {
             v.num_seconds().fmt(f)?;
@@ -120,15 +122,15 @@ impl Encodable for Song {
             e.emit_struct_field("title", 2, |e| self.title.encode(e))?;
             e.emit_struct_field("last_mod", 3, |e| {
                     e.emit_option(|e| match self.last_mod {
-                        Some(m) => e.emit_option_some(|e| m.to_timespec().sec.encode(e)),
-                        None => e.emit_option_none(),
-                    })
+                                      Some(m) => e.emit_option_some(|e| m.to_timespec().sec.encode(e)),
+                                      None => e.emit_option_none(),
+                                  })
                 })?;
             e.emit_struct_field("duration", 4, |e| {
                     e.emit_option(|e| match self.duration {
-                        Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
-                        None => e.emit_option_none(),
-                    })
+                                      Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                      None => e.emit_option_none(),
+                                  })
                 })?;
             e.emit_struct_field("place", 5, |e| self.place.encode(e))?;
             e.emit_struct_field("range", 6, |e| self.range.encode(e))?;
@@ -148,11 +150,7 @@ impl FromIter for Song {
             match &*line.0 {
                 "file" => result.file = line.1.to_owned(),
                 "Title" => result.title = Some(line.1.to_owned()),
-                "Last-Modified" => {
-                    result.last_mod = try!(strptime(&*line.1, "%Y-%m-%dT%H:%M:%S%Z")
-                        .map_err(ParseError::BadTime)
-                        .map(Some))
-                }
+                "Last-Modified" => result.last_mod = try!(strptime(&*line.1, "%Y-%m-%dT%H:%M:%S%Z").map_err(ParseError::BadTime).map(Some)),
                 "Name" => result.name = Some(line.1.to_owned()),
                 "Time" => result.duration = Some(Duration::seconds(try!(line.1.parse()))),
                 "Range" => result.range = Some(try!(line.1.parse())),
@@ -160,10 +158,10 @@ impl FromIter for Song {
                     match result.place {
                         None => {
                             result.place = Some(QueuePlace {
-                                id: Id(try!(line.1.parse())),
-                                pos: 0,
-                                prio: 0,
-                            })
+                                                    id: Id(try!(line.1.parse())),
+                                                    pos: 0,
+                                                    prio: 0,
+                                                })
                         }
                         Some(ref mut place) => place.id = Id(try!(line.1.parse())),
                     }
@@ -172,10 +170,10 @@ impl FromIter for Song {
                     match result.place {
                         None => {
                             result.place = Some(QueuePlace {
-                                pos: try!(line.1.parse()),
-                                id: Id(0),
-                                prio: 0,
-                            })
+                                                    pos: try!(line.1.parse()),
+                                                    id: Id(0),
+                                                    prio: 0,
+                                                })
                         }
                         Some(ref mut place) => place.pos = try!(line.1.parse()),
                     }
@@ -184,10 +182,10 @@ impl FromIter for Song {
                     match result.place {
                         None => {
                             result.place = Some(QueuePlace {
-                                prio: try!(line.1.parse()),
-                                id: Id(0),
-                                pos: 0,
-                            })
+                                                    prio: try!(line.1.parse()),
+                                                    id: Id(0),
+                                                    pos: 0,
+                                                })
                         }
                         Some(ref mut place) => place.prio = try!(line.1.parse()),
                     }

--- a/src/status.rs
+++ b/src/status.rs
@@ -71,44 +71,44 @@ impl Encodable for Status {
             e.emit_struct_field("nextsong", 9, |e| self.nextsong.encode(e))?;
             e.emit_struct_field("time", 10, |e| {
                     e.emit_option(|e| match self.time {
-                        Some(p) => {
-                            e.emit_option_some(|e| {
-                                e.emit_tuple(2, |e| {
-                                    e.emit_tuple_arg(0, |e| p.0.num_seconds().encode(e))?;
-                                    e.emit_tuple_arg(1, |e| p.1.num_seconds().encode(e))?;
-                                    Ok(())
-                                })
-                            })
-                        }
-                        None => e.emit_option_none(),
+                                      Some(p) => {
+                                          e.emit_option_some(|e| {
+                        e.emit_tuple(2, |e| {
+                            e.emit_tuple_arg(0, |e| p.0.num_seconds().encode(e))?;
+                            e.emit_tuple_arg(1, |e| p.1.num_seconds().encode(e))?;
+                            Ok(())
+                        })
                     })
+                                      }
+                                      None => e.emit_option_none(),
+                                  })
                 })?;
             e.emit_struct_field("elapsed", 11, |e| {
                     e.emit_option(|e| match self.elapsed {
-                        Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
-                        None => e.emit_option_none(),
-                    })
+                                      Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                      None => e.emit_option_none(),
+                                  })
 
                 })?;
             e.emit_struct_field("duration", 12, |e| {
                     e.emit_option(|e| match self.duration {
-                        Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
-                        None => e.emit_option_none(),
-                    })
+                                      Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                      None => e.emit_option_none(),
+                                  })
                 })?;
             e.emit_struct_field("bitrate", 13, |e| self.bitrate.encode(e))?;
             e.emit_struct_field("crossfade", 14, |e| {
                     e.emit_option(|e| match self.crossfade {
-                        Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
-                        None => e.emit_option_none(),
-                    })
+                                      Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                      None => e.emit_option_none(),
+                                  })
                 })?;
             e.emit_struct_field("mixrampdb", 15, |e| self.mixrampdb.encode(e))?;
             e.emit_struct_field("mixrampdelay", 16, |e| {
                     e.emit_option(|e| match self.mixrampdelay {
-                        Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
-                        None => e.emit_option_none(),
-                    })
+                                      Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                      None => e.emit_option_none(),
+                                  })
                 })?;
             e.emit_struct_field("audio", 17, |e| self.audio.encode(e))?;
             e.emit_struct_field("updating_db", 18, |e| self.updating_db.encode(e))?;
@@ -141,10 +141,10 @@ impl FromIter for Status {
                     match result.song {
                         None => {
                             result.song = Some(QueuePlace {
-                                id: Id(try!(line.1.parse())),
-                                pos: 0,
-                                prio: 0,
-                            })
+                                                   id: Id(try!(line.1.parse())),
+                                                   pos: 0,
+                                                   prio: 0,
+                                               })
                         }
                         Some(ref mut place) => place.id = Id(try!(line.1.parse())),
                     }
@@ -153,10 +153,10 @@ impl FromIter for Status {
                     match result.song {
                         None => {
                             result.song = Some(QueuePlace {
-                                pos: try!(line.1.parse()),
-                                id: Id(0),
-                                prio: 0,
-                            })
+                                                   pos: try!(line.1.parse()),
+                                                   id: Id(0),
+                                                   prio: 0,
+                                               })
                         }
                         Some(ref mut place) => place.pos = try!(line.1.parse()),
                     }
@@ -165,10 +165,10 @@ impl FromIter for Status {
                     match result.nextsong {
                         None => {
                             result.nextsong = Some(QueuePlace {
-                                id: Id(try!(line.1.parse())),
-                                pos: 0,
-                                prio: 0,
-                            })
+                                                       id: Id(try!(line.1.parse())),
+                                                       pos: 0,
+                                                       prio: 0,
+                                                   })
                         }
                         Some(ref mut place) => place.id = Id(try!(line.1.parse())),
                     }
@@ -177,24 +177,24 @@ impl FromIter for Status {
                     match result.nextsong {
                         None => {
                             result.nextsong = Some(QueuePlace {
-                                pos: try!(line.1.parse()),
-                                id: Id(0),
-                                prio: 0,
-                            })
+                                                       pos: try!(line.1.parse()),
+                                                       id: Id(0),
+                                                       prio: 0,
+                                                   })
                         }
                         Some(ref mut place) => place.pos = try!(line.1.parse()),
                     }
                 }
                 "time" => {
+                    let mut splits = line.1.splitn(2, ':').map(|v| v.parse().map_err(ParseError::BadInteger).map(Duration::seconds));
                     result.time = try!({
-                        let mut splits = line.1.splitn(2, ':').map(|v| v.parse().map_err(ParseError::BadInteger).map(Duration::seconds));
-                        match (splits.next(), splits.next()) {
-                            (Some(Ok(a)), Some(Ok(b))) => Ok(Some((a, b))),
-                            (Some(Err(e)), _) |
-                            (_, Some(Err(e))) => Err(e),
-                            _ => Ok(None),
-                        }
-                    })
+                                           match (splits.next(), splits.next()) {
+                                               (Some(Ok(a)), Some(Ok(b))) => Ok(Some((a, b))),
+                                               (Some(Err(e)), _) |
+                                               (_, Some(Err(e))) => Err(e),
+                                               _ => Ok(None),
+                                           }
+                                       })
                 }
                 // TODO" => float errors don't work on stable
                 "elapsed" => {
@@ -241,20 +241,14 @@ impl FromStr for AudioFormat {
     fn from_str(s: &str) -> Result<AudioFormat, ParseError> {
         let mut it = s.split(':');
         Ok(AudioFormat {
-            rate: try!(it.next()
-                .ok_or(ParseError::NoRate)
-                .and_then(|v| v.parse().map_err(ParseError::BadRate))),
-            bits: try!(it.next()
-                .ok_or(ParseError::NoBits)
-                .and_then(|v| if &*v == "f" {
-                    Ok(0)
-                } else {
-                    v.parse().map_err(ParseError::BadBits)
-                })),
-            chans: try!(it.next()
-                .ok_or(ParseError::NoChans)
-                .and_then(|v| v.parse().map_err(ParseError::BadChans))),
-        })
+               rate: try!(it.next().ok_or(ParseError::NoRate).and_then(|v| v.parse().map_err(ParseError::BadRate))),
+               bits: try!(it.next().ok_or(ParseError::NoBits).and_then(|v| if &*v == "f" {
+                                                                           Ok(0)
+                                                                       } else {
+                                                                           v.parse().map_err(ParseError::BadBits)
+                                                                       })),
+               chans: try!(it.next().ok_or(ParseError::NoChans).and_then(|v| v.parse().map_err(ParseError::BadChans))),
+           })
     }
 }
 
@@ -318,10 +312,10 @@ impl fmt::Display for ReplayGain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::ReplayGain::*;
         f.write_str(match *self {
-            Off => "off",
-            Track => "track",
-            Album => "album",
-            Auto => "auto",
-        })
+                        Off => "off",
+                        Track => "track",
+                        Album => "album",
+                        Auto => "auto",
+                    })
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -203,7 +203,12 @@ impl FromIter for Status {
                         .ok()
                         .map(|v| Duration::milliseconds((v * 1000.0) as i64))
                 }
-                "duration" => result.duration = Some(Duration::seconds(try!(line.1.parse()))),
+                "duration" => {
+                    result.duration = line.1
+                        .parse::<f32>()
+                        .ok()
+                        .map(|v| Duration::milliseconds((v * 1000.0) as i64))
+                }
                 "bitrate" => result.bitrate = Some(try!(line.1.parse())),
                 "xfade" => result.crossfade = Some(Duration::seconds(try!(line.1.parse()))),
                 // "mixrampdb" => 0.0, //get_field!(map, "mixrampdb"),

--- a/src/sticker.rs
+++ b/src/sticker.rs
@@ -13,9 +13,9 @@ impl FromStr for Sticker {
         match (parts.next(), parts.next()) {
             (Some(name), Some(value)) => {
                 Ok(Sticker {
-                    name: name.to_owned(),
-                    value: value.to_owned(),
-                })
+                       name: name.to_owned(),
+                       value: value.to_owned(),
+                   })
             }
             _ => Err(ParseError::BadValue(s.to_owned())),
         }

--- a/tests/helpers/daemon.rs
+++ b/tests/helpers/daemon.rs
@@ -96,10 +96,7 @@ impl Daemon {
         config.generate();
 
         // TODO: Factor out putting files in the music directory.
-        File::create(config.music_directory.join("empty.flac"))
-            .unwrap()
-            .write_all(EMPTY_FLAC_BYTES)
-            .unwrap();
+        File::create(config.music_directory.join("empty.flac")).unwrap().write_all(EMPTY_FLAC_BYTES).unwrap();
 
         let process = Command::new("mpd")
             .arg("--no-daemon")


### PR DESCRIPTION
I just copied and pasted the `elapsed` handling, and tested that it works locally.  Test suite passes, tested against MPD 0.19  and MPD 0.20.