### PR TITLE
Comment out pop_field macro to successfully build in Travis

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,8 +20,10 @@ macro_rules! get_field {
     ($map:expr, $name:expr) => { get_field_impl!(get, $map, $name) }
 }
 
-macro_rules! pop_field {
-    ($map:expr, bool $name:expr) => { get_field_impl!(remove, $map, bool $name) };
-    ($map:expr, opt $name:expr) => { get_field_impl!(remove, $map, opt $name) };
-    ($map:expr, $name:expr) => { get_field_impl!(remove, $map, $name) }
-}
+// Commenting out, since this is causing most recent build (v.0.0.12) to fail Travis Builds
+// Macro isn't used anywhere either, so commenting instead of removing in case we ever need it back
+//macro_rules! pop_field {
+    //($map:expr, bool $name:expr) => { get_field_impl!(remove, $map, bool $name) };
+    //($map:expr, opt $name:expr) => { get_field_impl!(remove, $map, opt $name) };
+    //($map:expr, $name:expr) => { get_field_impl!(remove, $map, $name) }
+//}


### PR DESCRIPTION
Noticed that the latest build of rust-mpd was failing in travis and the only thing I could find in the log was an error for this macro not being used anywhere. As such, I tried commenting it out and it seems to build without error now. 

Opted to comment it out in case it ever needs to be put back into the codebase, it's as simple as undoing the comments.