### PR TITLE
Adapt for more recent Rust releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ homepage = "https://github.com/kstep/rust-mpd"
 license = "MIT/Apache-2.0"
 name = "mpd"
 repository = "https://github.com/kstep/rust-mpd.git"
-version = "0.0.12"
+version = "0.0.13"
+edition = "2018"
 
 [dependencies]
 bufstream = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/kstep/rust-mpd"
 license = "MIT/Apache-2.0"
 name = "mpd"
 repository = "https://github.com/kstep/rust-mpd.git"
-version = "0.0.13"
+version = "0.1.0"
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 bufstream = "0.1.1"
 rustc-serialize = "0.3.16"
-time = "0.1.34"
+time = "0.2"
 
 [dev-dependencies]
 tempdir = "0.3.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,13 +58,13 @@ impl<S: Read + Write> Client<S> {
         let mut socket = BufStream::new(socket);
 
         let mut banner = String::new();
-        try!(socket.read_line(&mut banner));
+        socket.read_line(&mut banner)?;
 
         if !banner.starts_with("OK MPD ") {
             return Err(From::from(ProtoError::BadBanner));
         }
 
-        let version = try!(banner[7..].trim().parse::<Version>());
+        let version = banner[7..].trim().parse::<Version>()?;
 
         Ok(Client {
                socket: socket,
@@ -610,7 +610,7 @@ impl<S: Read + Write> Proto for Client<S> {
 
     fn read_line(&mut self) -> Result<String> {
         let mut buf = String::new();
-        try!(self.socket.read_line(&mut buf));
+        self.socket.read_line(&mut buf)?;
         if buf.ends_with('\n') {
             buf.pop();
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,24 +7,25 @@
 
 use bufstream::BufStream;
 
-use convert::*;
-use error::{Error, ProtoError, Result};
-use message::{Channel, Message};
-use mount::{Mount, Neighbor};
-use output::Output;
-use playlist::Playlist;
-use plugin::Plugin;
-use proto::*;
-use search::{Query, Window, Term};
-use song::{Id, Song};
-use stats::Stats;
-use status::{ReplayGain, Status};
+use crate::convert::*;
+use crate::error::{Error, ProtoError, Result};
+use crate::message::{Channel, Message};
+use crate::mount::{Mount, Neighbor};
+use crate::output::Output;
+use crate::playlist::Playlist;
+use crate::plugin::Plugin;
+use crate::proto::*;
+use crate::search::{Query, Window, Term};
+use crate::song::{Id, Song};
+use crate::stats::Stats;
+use crate::status::{ReplayGain, Status};
+use crate::sticker::Sticker;
+use crate::version::Version;
+
 use std::convert::From;
 use std::io::{BufRead, Lines, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::collections::HashMap;
-use sticker::Sticker;
-use version::Version;
 
 // Client {{{
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -9,7 +9,7 @@ use crate::song::{self, Id, Song};
 use std::collections::BTreeMap;
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 
-use time::Duration;
+use std::time::Duration;
 
 #[doc(hidden)]
 pub trait FromMap: Sized {
@@ -88,7 +88,7 @@ impl ToSeconds for f64 {
 
 impl ToSeconds for Duration {
     fn to_seconds(self) -> f64 {
-        self.num_milliseconds() as f64 / 1000.0
+        self.as_secs_f64()
     }
 }
 // }}}
@@ -243,7 +243,7 @@ impl ToSongRange for Range<Duration> {
 
 impl ToSongRange for Range<u32> {
     fn to_range(self) -> song::Range {
-        song::Range(Duration::seconds(self.start as i64), Some(Duration::seconds(self.end as i64)))
+        song::Range(Duration::from_secs(self.start as u64), Some(Duration::from_secs(self.end as u64)))
     }
 }
 
@@ -255,25 +255,25 @@ impl ToSongRange for RangeFrom<Duration> {
 
 impl ToSongRange for RangeFrom<u32> {
     fn to_range(self) -> song::Range {
-        song::Range(Duration::seconds(self.start as i64), None)
+        song::Range(Duration::from_secs(self.start as u64), None)
     }
 }
 
 impl ToSongRange for RangeTo<Duration> {
     fn to_range(self) -> song::Range {
-        song::Range(Duration::zero(), Some(self.end))
+        song::Range(Duration::from_secs(0), Some(self.end))
     }
 }
 
 impl ToSongRange for RangeTo<u32> {
     fn to_range(self) -> song::Range {
-        song::Range(Duration::zero(), Some(Duration::seconds(self.end as i64)))
+        song::Range(Duration::from_secs(0), Some(Duration::from_secs(self.end as u64)))
     }
 }
 
 impl ToSongRange for RangeFull {
     fn to_range(self) -> song::Range {
-        song::Range(Duration::zero(), None)
+        song::Range(Duration::from_secs(0), None)
     }
 }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,11 +1,11 @@
 #![allow(missing_docs)]
 //! These are inner traits to support methods overloading for the `Client`
 
-use error::Error;
-use output::Output;
-use playlist::Playlist;
-use proto::ToArguments;
-use song::{self, Id, Song};
+use crate::error::Error;
+use crate::output::Output;
+use crate::playlist::Playlist;
+use crate::proto::ToArguments;
+use crate::song::{self, Id, Song};
 use std::collections::BTreeMap;
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -301,7 +301,7 @@ impl<'a, T: ToSongPath> ToSongPath for &'a T {
     }
 }
 
-impl ToSongPath for AsRef<str> {
+impl ToSongPath for dyn AsRef<str> {
     fn to_path(&self) -> &str {
         self.as_ref()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,10 +76,13 @@ impl FromStr for ErrorCode {
     }
 }
 
-impl StdError for ErrorCode {
-    fn description(&self) -> &str {
+impl StdError for ErrorCode { }
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::ErrorCode::*;
-        match *self {
+
+        let desc = match *self {
             NotList => "not a list",
             Argument => "invalid argument",
             Password => "invalid password",
@@ -93,13 +96,9 @@ impl StdError for ErrorCode {
             UpdateAlready => "already updating",
             PlayerSync => "player syncing",
             Exist => "already exists",
-        }
-    }
-}
+        };
 
-impl fmt::Display for ErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str(desc)
     }
 }
 
@@ -116,15 +115,11 @@ pub struct ServerError {
     pub detail: String,
 }
 
+impl StdError for ServerError { }
+
 impl fmt::Display for ServerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} error (`{}') at {}", self.code, self.detail, self.pos)
-    }
-}
-
-impl StdError for ServerError {
-    fn description(&self) -> &str {
-        self.code.description()
     }
 }
 
@@ -182,20 +177,12 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 impl StdError for Error {
-    fn cause(&self) -> Option<&dyn StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
             Error::Io(ref err) => Some(err),
             Error::Parse(ref err) => Some(err),
             Error::Proto(ref err) => Some(err),
             Error::Server(ref err) => Some(err),
-        }
-    }
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref err) => err.description(),
-            Error::Parse(ref err) => err.description(),
-            Error::Proto(ref err) => err.description(),
-            Error::Server(ref err) => err.description(),
         }
     }
 }
@@ -296,16 +283,13 @@ pub enum ParseError {
     BadErrorCode(usize),
 }
 
+impl StdError for ParseError { }
+
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl StdError for ParseError {
-    fn description(&self) -> &str {
         use self::ParseError::*;
-        match *self {
+
+        let desc = match *self {
             BadInteger(_) => "invalid integer",
             BadFloat(_) => "invalid float",
             BadValue(_) => "invalid value",
@@ -325,7 +309,9 @@ impl StdError for ParseError {
             BadChans(_) => "invalid audio format channels",
             BadState(_) => "invalid playing state",
             BadErrorCode(_) => "unknown error code",
-        }
+        };
+
+        write!(f, "{}", desc)
     }
 }
 
@@ -374,21 +360,19 @@ pub enum ProtoError {
     BadSticker,
 }
 
+impl StdError for ProtoError { }
+
 impl fmt::Display for ProtoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl StdError for ProtoError {
-    fn description(&self) -> &str {
-        match *self {
+        let desc = match *self {
             ProtoError::NotOk => "OK expected",
             ProtoError::NotPair => "pair expected",
             ProtoError::BadBanner => "banner error",
             ProtoError::NoField(_) => "missing field",
             ProtoError::BadSticker => "sticker error",
-        }
+        };
+
+        write!(f, "{}", desc)
     }
 }
 // }}}

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ impl FromStr for ErrorCode {
     type Err = ParseError;
     fn from_str(s: &str) -> result::Result<ErrorCode, ParseError> {
         use self::ErrorCode::*;
-        match try!(s.parse()) {
+        match s.parse()? {
             1 => Ok(NotList),
             2 => Ok(Argument),
             3 => Ok(Password),

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ use std::result;
 use std::str::FromStr;
 use std::string::ParseError as StringParseError;
 use time::ParseError as TimeParseError;
+use time::ConversionRangeError as TimeConversionRangeError;
 
 // Server errors {{{
 /// Server error codes, as defined in [libmpdclient](http://www.musicpd.org/doc/libmpdclient/protocol_8h_source.html)
@@ -234,6 +235,12 @@ impl From<ServerError> for Error {
         Error::Server(e)
     }
 }
+
+impl From<TimeConversionRangeError> for Error {
+    fn from(e: TimeConversionRangeError) -> Error {
+        Error::Parse(ParseError::BadTimeConversion(e))
+    }
+}
 // }}}
 
 // Parse errors {{{
@@ -248,6 +255,8 @@ pub enum ParseError {
     BadValue(String),
     /// date/time parsing error
     BadTime(TimeParseError),
+    /// date/time to duration (Unix time) conversion error
+    BadTimeConversion(TimeConversionRangeError),
     /// invalid version format (should be x.y.z)
     BadVersion,
     /// the response is not an `ACK` (not an error)
@@ -294,6 +303,7 @@ impl fmt::Display for ParseError {
             BadFloat(_) => "invalid float",
             BadValue(_) => "invalid value",
             BadTime(_) => "invalid date/time",
+            BadTimeConversion(_) => "invalid date/time conversion",
             BadVersion => "invalid version",
             NotAck => "not an ACK",
             BadPair => "invalid pair",
@@ -318,6 +328,12 @@ impl fmt::Display for ParseError {
 impl From<TimeParseError> for ParseError {
     fn from(e: TimeParseError) -> ParseError {
         ParseError::BadTime(e)
+    }
+}
+
+impl From<TimeConversionRangeError> for ParseError {
+    fn from(e: TimeConversionRangeError) -> ParseError {
+        ParseError::BadTimeConversion(e)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -182,7 +182,7 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 impl StdError for Error {
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::Io(ref err) => Some(err),
             Error::Parse(ref err) => Some(err),

--- a/src/idle.rs
+++ b/src/idle.rs
@@ -26,10 +26,10 @@
 //! to original `Client` struct, thus enforcing MPD contract in regards of (im)possibility
 //! to send commands while in "idle" mode.
 
-use client::Client;
+use crate::client::Client;
+use crate::error::{Error, ParseError};
+use crate::proto::Proto;
 
-use error::{Error, ParseError};
-use proto::Proto;
 use std::fmt;
 use std::io::{Read, Write};
 use std::mem::forget;
@@ -110,7 +110,7 @@ impl fmt::Display for Subsystem {
 }
 
 use std::result::Result as StdResult;
-impl<'a> ::proto::ToArguments for Subsystem {
+impl<'a> crate::proto::ToArguments for Subsystem {
     fn to_arguments<F, E>(&self, f: &mut F) -> StdResult<(), E>
         where F: FnMut(&str) -> StdResult<(), E>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,6 @@
 //! # }
 //! ```
 
-extern crate rustc_serialize;
-extern crate time;
-extern crate bufstream;
-
 mod macros;
 mod convert;
 pub mod error;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,15 +2,15 @@
 
 macro_rules! get_field_impl {
     ($op:ident, $map:expr, bool $name:expr) => {
-        try!($map.$op($name).ok_or(Error::Proto(ProtoError::NoField($name)))
-             .map(|v| v == "1"))
+        $map.$op($name).ok_or(Error::Proto(ProtoError::NoField($name)))
+             .map(|v| v == "1")?
     };
     ($op:ident, $map:expr, opt $name:expr) => {
-        try!($map.$op($name).map(|v| v.parse().map(Some)).unwrap_or(Ok(None)))
+        $map.$op($name).map(|v| v.parse().map(Some)).unwrap_or(Ok(None))?
     };
     ($op:ident, $map:expr, $name:expr) => {
-        try!($map.$op($name).ok_or(Error::Proto(ProtoError::NoField($name)))
-             .and_then(|v| v.parse().map_err(|e| Error::Parse(From::from(e)))))
+        $map.$op($name).ok_or(Error::Proto(ProtoError::NoField($name)))
+             .and_then(|v| v.parse().map_err(|e| Error::Parse(From::from(e))))?
     };
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,9 +8,8 @@
 //! Also client can get asynchronous notifications about new messages from subscribed
 //! channels with `idle` command, by waiting for `message` subsystem events.
 
-use convert::FromMap;
-
-use error::{Error, ProtoError};
+use crate::convert::FromMap;
+use crate::error::{Error, ProtoError};
 
 use std::collections::BTreeMap;
 use std::fmt;

--- a/src/message.rs
+++ b/src/message.rs
@@ -27,8 +27,8 @@ pub struct Message {
 impl FromMap for Message {
     fn from_map(map: BTreeMap<String, String>) -> Result<Message, Error> {
         Ok(Message {
-               channel: Channel(try!(map.get("channel").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("channel"))))),
-               message: try!(map.get("message").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("message")))),
+               channel: Channel(map.get("channel").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("channel")))?),
+               message: map.get("message").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("message")))?,
            })
     }
 }

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -9,9 +9,9 @@
 //! Possible, but inactive, mounts are named "neighbors" and can be
 //! listed with `neighbors()` method.
 
-use convert::FromMap;
+use crate::convert::FromMap;
+use crate::error::{Error, ProtoError};
 
-use error::{Error, ProtoError};
 use std::collections::BTreeMap;
 
 /// Mount point

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -26,8 +26,8 @@ pub struct Mount {
 impl FromMap for Mount {
     fn from_map(map: BTreeMap<String, String>) -> Result<Mount, Error> {
         Ok(Mount {
-               name: try!(map.get("mount").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("mount")))),
-               storage: try!(map.get("storage").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("storage")))),
+               name: map.get("mount").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("mount")))?,
+               storage: map.get("storage").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("storage")))?,
            })
     }
 }
@@ -44,8 +44,8 @@ pub struct Neighbor {
 impl FromMap for Neighbor {
     fn from_map(map: BTreeMap<String, String>) -> Result<Neighbor, Error> {
         Ok(Neighbor {
-               name: try!(map.get("name").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("name")))),
-               storage: try!(map.get("neighbor").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("neighbor")))),
+               name: map.get("name").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("name")))?,
+               storage: map.get("neighbor").map(|s| s.to_owned()).ok_or(Error::Proto(ProtoError::NoField("neighbor")))?,
            })
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -21,7 +21,7 @@ impl FromMap for Output {
     fn from_map(map: BTreeMap<String, String>) -> Result<Output, Error> {
         Ok(Output {
                id: get_field!(map, "outputid"),
-               name: try!(map.get("outputname").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("outputname")))),
+               name: map.get("outputname").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("outputname")))?,
                enabled: get_field!(map, bool "outputenabled"),
            })
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,8 +1,8 @@
 //! The module describes output
 
 
-use convert::FromMap;
-use error::{Error, ProtoError};
+use crate::convert::FromMap;
+use crate::error::{Error, ProtoError};
 use std::collections::BTreeMap;
 use std::convert::From;
 

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -18,10 +18,10 @@ pub struct Playlist {
 impl FromMap for Playlist {
     fn from_map(map: BTreeMap<String, String>) -> Result<Playlist, Error> {
         Ok(Playlist {
-               name: try!(map.get("playlist").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("playlist")))),
-               last_mod: try!(map.get("Last-Modified")
+               name: map.get("playlist").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("playlist")))?,
+               last_mod: map.get("Last-Modified")
                 .ok_or(Error::Proto(ProtoError::NoField("Last-Modified")))
-                .and_then(|v| strptime(&*v, "%Y-%m-%dT%H:%M:%S%Z").map_err(From::from))),
+                .and_then(|v| strptime(&*v, "%Y-%m-%dT%H:%M:%S%Z").map_err(From::from))?,
            })
     }
 }

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -1,7 +1,7 @@
 //! The module defines playlist data structures
 
-use convert::FromMap;
-use error::{Error, ProtoError};
+use crate::convert::FromMap;
+use crate::error::{Error, ProtoError};
 
 use std::collections::BTreeMap;
 use time::{Tm, strptime};

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -19,7 +19,7 @@ impl FromIter for Vec<Plugin> {
         let mut result = Vec::new();
         let mut plugin: Option<Plugin> = None;
         for reply in iter {
-            let (a, b) = try!(reply);
+            let (a, b) = reply?;
             match &*a {
                 "plugin" => {
                     plugin.map(|p| result.push(p));

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,7 +1,7 @@
 //! The module defines decoder plugin data structures
 
-use convert::FromIter;
-use error::Error;
+use crate::convert::FromIter;
+use crate::error::Error;
 
 /// Decoder plugin
 #[derive(Clone, Debug, PartialEq, RustcEncodable)]

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -2,10 +2,11 @@
 #![allow(missing_docs)]
 
 use bufstream::BufStream;
-use convert::{FromIter, FromMap};
-use error::{Error, ProtoError, Result, ParseError};
 
-use reply::Reply;
+use crate::convert::{FromIter, FromMap};
+use crate::error::{Error, ProtoError, Result, ParseError};
+use crate::reply::Reply;
+
 use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, Lines, Read, Write};
@@ -169,7 +170,7 @@ pub trait Proto {
 
 
 pub trait ToArguments {
-    fn to_arguments<F, E>(&self, &mut F) -> StdResult<(), E> where F: FnMut(&str) -> StdResult<(), E>;
+    fn to_arguments<F, E>(&self, _: &mut F) -> StdResult<(), E> where F: FnMut(&str) -> StdResult<(), E>;
 }
 
 impl ToArguments for () {
@@ -205,11 +206,11 @@ argument_for_display!{u32}
 argument_for_display!{f32}
 argument_for_display!{f64}
 argument_for_display!{usize}
-argument_for_display!{::status::ReplayGain}
+argument_for_display!{crate::status::ReplayGain}
 argument_for_display!{String}
-argument_for_display!{::song::Id}
-argument_for_display!{::song::Range}
-argument_for_display!{::message::Channel}
+argument_for_display!{crate::song::Id}
+argument_for_display!{crate::song::Range}
+argument_for_display!{crate::message::Channel}
 
 macro_rules! argument_for_tuple {
     ( $($t:ident: $T: ident),+ ) => {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -123,7 +123,7 @@ pub trait Proto {
 
     fn drain(&mut self) -> Result<()> {
         loop {
-            let reply = try!(self.read_line());
+            let reply = self.read_line()?;
             match &*reply {
                 "OK" | "list_OK" => break,
                 _ => (),
@@ -133,7 +133,7 @@ pub trait Proto {
     }
 
     fn expect_ok(&mut self) -> Result<()> {
-        let line = try!(self.read_line());
+        let line = self.read_line()?;
 
         match line.parse::<Reply>() {
             Ok(Reply::Ok) => Ok(()),
@@ -144,7 +144,7 @@ pub trait Proto {
     }
 
     fn read_pair(&mut self) -> Result<(String, String)> {
-        let line = try!(self.read_line());
+        let line = self.read_line()?;
 
         match line.parse::<Reply>() {
             Ok(Reply::Pair(a, b)) => Ok((a, b)),

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -4,7 +4,7 @@
 //! all possible server replies.
 
 
-use error::{ParseError, ServerError};
+use crate::error::{ParseError, ServerError};
 use std::str::FromStr;
 
 /// All possible MPD server replies

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 // TODO: unfinished functionality
 
-use proto::ToArguments;
+use crate::proto::ToArguments;
 use std::borrow::Cow;
 use std::convert::Into;
 use std::fmt;
@@ -116,7 +116,7 @@ impl ToArguments for Window {
 #[cfg(test)]
 mod test {
     use super::*;
-    use proto::ToArguments;
+    use crate::proto::ToArguments;
 
     fn collect<I: ToArguments>(arguments: I) -> Vec<String> {
         let mut output = Vec::<String>::new();

--- a/src/song.rs
+++ b/src/song.rs
@@ -1,8 +1,8 @@
 //! The module defines song structs and methods.
 
-use convert::FromIter;
+use crate::convert::FromIter;
+use crate::error::{Error, ParseError};
 
-use error::{Error, ParseError};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 use std::collections::BTreeMap;

--- a/src/song.rs
+++ b/src/song.rs
@@ -147,49 +147,49 @@ impl FromIter for Song {
         let mut result = Song::default();
 
         for res in iter {
-            let line = try!(res);
+            let line = res?;
             match &*line.0 {
                 "file" => result.file = line.1.to_owned(),
                 "Title" => result.title = Some(line.1.to_owned()),
-                "Last-Modified" => result.last_mod = try!(strptime(&*line.1, "%Y-%m-%dT%H:%M:%S%Z").map_err(ParseError::BadTime).map(Some)),
+                "Last-Modified" => result.last_mod = strptime(&*line.1, "%Y-%m-%dT%H:%M:%S%Z").map_err(ParseError::BadTime).map(Some)?,
                 "Artist" => result.artist = Some(line.1.to_owned()),
                 "Name" => result.name = Some(line.1.to_owned()),
-                "Time" => result.duration = Some(Duration::seconds(try!(line.1.parse()))),
-                "Range" => result.range = Some(try!(line.1.parse())),
+                "Time" => result.duration = Some(Duration::seconds(line.1.parse()?)),
+                "Range" => result.range = Some(line.1.parse()?),
                 "Id" => {
                     match result.place {
                         None => {
                             result.place = Some(QueuePlace {
-                                                    id: Id(try!(line.1.parse())),
+                                                    id: Id(line.1.parse()?),
                                                     pos: 0,
                                                     prio: 0,
                                                 })
                         }
-                        Some(ref mut place) => place.id = Id(try!(line.1.parse())),
+                        Some(ref mut place) => place.id = Id(line.1.parse()?),
                     }
                 }
                 "Pos" => {
                     match result.place {
                         None => {
                             result.place = Some(QueuePlace {
-                                                    pos: try!(line.1.parse()),
+                                                    pos: line.1.parse()?,
                                                     id: Id(0),
                                                     prio: 0,
                                                 })
                         }
-                        Some(ref mut place) => place.pos = try!(line.1.parse()),
+                        Some(ref mut place) => place.pos = line.1.parse()?,
                     }
                 }
                 "Prio" => {
                     match result.place {
                         None => {
                             result.place = Some(QueuePlace {
-                                                    prio: try!(line.1.parse()),
+                                                    prio: line.1.parse()?,
                                                     id: Id(0),
                                                     pos: 0,
                                                 })
                         }
-                        Some(ref mut place) => place.prio = try!(line.1.parse()),
+                        Some(ref mut place) => place.prio = line.1.parse()?,
                     }
                 }
                 _ => {

--- a/src/song.rs
+++ b/src/song.rs
@@ -8,7 +8,8 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
-use time::{Duration, Tm, strptime};
+use time::{Tm, strptime};
+use std::time::Duration;
 
 /// Song ID
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Default)]
@@ -50,10 +51,10 @@ pub struct Range(pub Duration, pub Option<Duration>);
 impl Encodable for Range {
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         e.emit_tuple(2, |e| {
-            e.emit_tuple_arg(0, |e| e.emit_i64(self.0.num_seconds()))?;
+            e.emit_tuple_arg(0, |e| e.emit_u64(self.0.as_secs()))?;
             e.emit_tuple_arg(1, |e| {
                 e.emit_option(|e| match self.1 {
-                                  Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                  Some(d) => e.emit_option_some(|e| d.as_secs().encode(e)),
                                   None => e.emit_option_none(),
                               })
             })
@@ -63,16 +64,16 @@ impl Encodable for Range {
 
 impl Default for Range {
     fn default() -> Range {
-        Range(Duration::seconds(0), None)
+        Range(Duration::from_secs(0), None)
     }
 }
 
 impl fmt::Display for Range {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.num_seconds().fmt(f)?;
+        self.0.as_secs().fmt(f)?;
         f.write_str(":")?;
         if let Some(v) = self.1 {
-            v.num_seconds().fmt(f)?;
+            v.as_secs().fmt(f)?;
         }
         Ok(())
     }
@@ -83,10 +84,10 @@ impl FromStr for Range {
     fn from_str(s: &str) -> Result<Range, ParseError> {
         let mut splits = s.split('-').flat_map(|v| v.parse().into_iter());
         match (splits.next(), splits.next()) {
-            (Some(s), Some(e)) => Ok(Range(Duration::seconds(s), Some(Duration::seconds(e)))),
-            (None, Some(e)) => Ok(Range(Duration::zero(), Some(Duration::seconds(e)))),
-            (Some(s), None) => Ok(Range(Duration::seconds(s), None)),
-            (None, None) => Ok(Range(Duration::zero(), None)),
+            (Some(s), Some(e)) => Ok(Range(Duration::from_secs(s), Some(Duration::from_secs(e)))),
+            (None, Some(e)) => Ok(Range(Duration::from_secs(0), Some(Duration::from_secs(e)))),
+            (Some(s), None) => Ok(Range(Duration::from_secs(s), None)),
+            (None, None) => Ok(Range(Duration::from_secs(0), None)),
         }
     }
 }
@@ -129,7 +130,7 @@ impl Encodable for Song {
             e.emit_struct_field("artist", 4, |e| self.artist.encode(e))?;
             e.emit_struct_field("duration", 5, |e| {
                     e.emit_option(|e| match self.duration {
-                                      Some(d) => e.emit_option_some(|e| d.num_seconds().encode(e)),
+                                      Some(d) => e.emit_option_some(|e| d.as_secs().encode(e)),
                                       None => e.emit_option_none(),
                                   })
                 })?;
@@ -154,7 +155,7 @@ impl FromIter for Song {
                 "Last-Modified" => result.last_mod = strptime(&*line.1, "%Y-%m-%dT%H:%M:%S%Z").map_err(ParseError::BadTime).map(Some)?,
                 "Artist" => result.artist = Some(line.1.to_owned()),
                 "Name" => result.name = Some(line.1.to_owned()),
-                "Time" => result.duration = Some(Duration::seconds(line.1.parse()?)),
+                "Time" => result.duration = Some(Duration::from_secs(line.1.parse()?)),
                 "Range" => result.range = Some(line.1.parse()?),
                 "Id" => {
                     match result.place {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -60,15 +60,15 @@ impl FromIter for Stats {
         let mut result = Stats::default();
 
         for res in iter {
-            let line = try!(res);
+            let line = res?;
             match &*line.0 {
-                "artists" => result.artists = try!(line.1.parse()),
-                "albums" => result.albums = try!(line.1.parse()),
-                "songs" => result.songs = try!(line.1.parse()),
-                "uptime" => result.uptime = Duration::seconds(try!(line.1.parse())),
-                "playtime" => result.playtime = Duration::seconds(try!(line.1.parse())),
-                "db_playtime" => result.db_playtime = Duration::seconds(try!(line.1.parse())),
-                "db_update" => result.db_update = Timespec::new(try!(line.1.parse()), 0),
+                "artists" => result.artists = line.1.parse()?,
+                "albums" => result.albums = line.1.parse()?,
+                "songs" => result.songs = line.1.parse()?,
+                "uptime" => result.uptime = Duration::seconds(line.1.parse()?),
+                "playtime" => result.playtime = Duration::seconds(line.1.parse()?),
+                "db_playtime" => result.db_playtime = Duration::seconds(line.1.parse()?),
+                "db_update" => result.db_update = Timespec::new(line.1.parse()?, 0),
                 _ => (),
             }
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,8 @@
 //! The module describes DB and playback statistics
 
-use convert::FromIter;
+use crate::convert::FromIter;
+use crate::error::Error;
 
-use error::Error;
 use rustc_serialize::{Encodable, Encoder};
 use time::{Duration, Timespec};
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -4,7 +4,6 @@ use crate::convert::FromIter;
 use crate::error::Error;
 
 use rustc_serialize::{Encodable, Encoder};
-use time::Timespec;
 use std::time::Duration;
 
 /// DB and playback statistics
@@ -22,8 +21,8 @@ pub struct Stats {
     pub playtime: Duration,
     /// total playback time for all songs in DB, seconds resolution
     pub db_playtime: Duration,
-    /// last DB update timestamp, seconds resolution
-    pub db_update: Timespec,
+    /// last DB update timestamp in seconds since Epoch, seconds resolution
+    pub db_update: Duration,
 }
 
 impl Encodable for Stats {
@@ -35,7 +34,7 @@ impl Encodable for Stats {
             e.emit_struct_field("uptime", 3, |e| self.uptime.as_secs().encode(e))?;
             e.emit_struct_field("playtime", 4, |e| self.playtime.as_secs().encode(e))?;
             e.emit_struct_field("db_playtime", 5, |e| self.db_playtime.as_secs().encode(e))?;
-            e.emit_struct_field("db_update", 6, |e| self.db_update.sec.encode(e))?;
+            e.emit_struct_field("db_update", 6, |e| self.db_update.as_secs().encode(e))?;
             Ok(())
         })
     }
@@ -50,7 +49,7 @@ impl Default for Stats {
             uptime: Duration::from_secs(0),
             playtime: Duration::from_secs(0),
             db_playtime: Duration::from_secs(0),
-            db_update: Timespec::new(0, 0),
+            db_update: Duration::from_secs(0),
         }
     }
 }
@@ -69,7 +68,7 @@ impl FromIter for Stats {
                 "uptime" => result.uptime = Duration::from_secs(line.1.parse()?),
                 "playtime" => result.playtime = Duration::from_secs(line.1.parse()?),
                 "db_playtime" => result.db_playtime = Duration::from_secs(line.1.parse()?),
-                "db_update" => result.db_update = Timespec::new(line.1.parse()?, 0),
+                "db_update" => result.db_update = Duration::from_secs(line.1.parse()?),
                 _ => (),
             }
         }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -4,7 +4,8 @@ use crate::convert::FromIter;
 use crate::error::Error;
 
 use rustc_serialize::{Encodable, Encoder};
-use time::{Duration, Timespec};
+use time::Timespec;
+use std::time::Duration;
 
 /// DB and playback statistics
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -31,9 +32,9 @@ impl Encodable for Stats {
             e.emit_struct_field("artists", 0, |e| self.artists.encode(e))?;
             e.emit_struct_field("albums", 1, |e| self.albums.encode(e))?;
             e.emit_struct_field("songs", 2, |e| self.songs.encode(e))?;
-            e.emit_struct_field("uptime", 3, |e| self.uptime.num_seconds().encode(e))?;
-            e.emit_struct_field("playtime", 4, |e| self.playtime.num_seconds().encode(e))?;
-            e.emit_struct_field("db_playtime", 5, |e| self.db_playtime.num_seconds().encode(e))?;
+            e.emit_struct_field("uptime", 3, |e| self.uptime.as_secs().encode(e))?;
+            e.emit_struct_field("playtime", 4, |e| self.playtime.as_secs().encode(e))?;
+            e.emit_struct_field("db_playtime", 5, |e| self.db_playtime.as_secs().encode(e))?;
             e.emit_struct_field("db_update", 6, |e| self.db_update.sec.encode(e))?;
             Ok(())
         })
@@ -46,9 +47,9 @@ impl Default for Stats {
             artists: 0,
             albums: 0,
             songs: 0,
-            uptime: Duration::seconds(0),
-            playtime: Duration::seconds(0),
-            db_playtime: Duration::seconds(0),
+            uptime: Duration::from_secs(0),
+            playtime: Duration::from_secs(0),
+            db_playtime: Duration::from_secs(0),
             db_update: Timespec::new(0, 0),
         }
     }
@@ -65,9 +66,9 @@ impl FromIter for Stats {
                 "artists" => result.artists = line.1.parse()?,
                 "albums" => result.albums = line.1.parse()?,
                 "songs" => result.songs = line.1.parse()?,
-                "uptime" => result.uptime = Duration::seconds(line.1.parse()?),
-                "playtime" => result.playtime = Duration::seconds(line.1.parse()?),
-                "db_playtime" => result.db_playtime = Duration::seconds(line.1.parse()?),
+                "uptime" => result.uptime = Duration::from_secs(line.1.parse()?),
+                "playtime" => result.playtime = Duration::from_secs(line.1.parse()?),
+                "db_playtime" => result.db_playtime = Duration::from_secs(line.1.parse()?),
                 "db_update" => result.db_update = Timespec::new(line.1.parse()?, 0),
                 _ => (),
             }

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,10 +1,10 @@
 //! The module defines MPD status data structures
 
-use convert::FromIter;
+use crate::convert::FromIter;
+use crate::error::{Error, ParseError};
+use crate::song::{Id, QueuePlace};
 
-use error::{Error, ParseError};
 use rustc_serialize::{Encodable, Encoder};
-use song::{Id, QueuePlace};
 use std::fmt;
 use std::str::FromStr;
 use time::Duration;

--- a/src/sticker.rs
+++ b/src/sticker.rs
@@ -1,4 +1,4 @@
-use error::ParseError;
+use crate::error::ParseError;
 use std::str::FromStr;
 
 pub struct Sticker {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,7 +1,7 @@
 //! This module defines MPD version type and parsing code
 
 
-use error::ParseError;
+use crate::error::ParseError;
 use std::str::FromStr;
 
 // Version {{{

--- a/tests/options.rs
+++ b/tests/options.rs
@@ -1,9 +1,8 @@
 extern crate mpd;
-extern crate time;
 
 mod helpers;
 use helpers::connect;
-use time::Duration;
+use std::time::Duration;
 
 #[test]
 fn status() {
@@ -46,7 +45,7 @@ test_option!(single, true, false);
 test_option!(random, true, false);
 test_option!(repeat, true, false);
 // test_option!(mixrampdb, 1.0f32, 0.0f32);
-// test_option!(mixrampdelay, 1 => Some(Duration::seconds(1)), 0 => None);
+// test_option!(mixrampdelay, 1 => Some(Duration::from_secs(1)), 0 => None);
 
 #[test]
 fn volume() {
@@ -63,12 +62,12 @@ fn volume() {
 fn crossfade() {
     let mut mpd = connect();
     mpd.crossfade(1000).unwrap();
-    assert_eq!(mpd.status().unwrap().crossfade, Some(Duration::seconds(1000)));
+    assert_eq!(mpd.status().unwrap().crossfade, Some(Duration::from_secs(1000)));
     mpd.crossfade(0).unwrap();
     assert_eq!(mpd.status().unwrap().crossfade,
                if mpd.version >= mpd::Version(0, 19, 0) {
                    None
                } else {
-                   Some(Duration::zero())
+                   Some(Duration::from_secs(0))
                });
 }


### PR DESCRIPTION
Fix some warnings emitted by a 1.39 compiler. No functional changes.