### PR TITLE
Allow tags with multiple values

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -21,9 +21,9 @@ pub trait FromIter: Sized {
     fn from_iter<I: Iterator<Item = Result<(String, String), Error>>>(iter: I) -> Result<Self, Error>;
 }
 
-impl<T: FromIter> FromMap for T {
-    fn from_map(map: BTreeMap<String, String>) -> Result<Self, Error> {
-        FromIter::from_iter(map.into_iter().map(Ok))
+impl<T: FromMap> FromIter for T {
+    fn from_iter<I: Iterator<Item = Result<(String, String), Error>>>(iter: I) -> Result<Self, Error> {
+        iter.collect::<Result<BTreeMap<_, _>, _>>().and_then(FromMap::from_map)
     }
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -3,11 +3,10 @@
 
 use bufstream::BufStream;
 
-use crate::convert::{FromIter, FromMap};
+use crate::convert::FromIter;
 use crate::error::{Error, ProtoError, Result, ParseError};
 use crate::reply::Reply;
 
-use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{self, Lines, Read, Write};
 use std::result::Result as StdResult;
@@ -43,16 +42,16 @@ pub struct Maps<'a, I: 'a> {
 impl<'a, I> Iterator for Maps<'a, I>
     where I: Iterator<Item = io::Result<String>>
 {
-    type Item = Result<BTreeMap<String, String>>;
-    fn next(&mut self) -> Option<Result<BTreeMap<String, String>>> {
+    type Item = Result<Vec<(String, String)>>;
+    fn next(&mut self) -> Option<Result<Vec<(String, String)>>> {
         if self.done {
             return None;
         }
 
-        let mut map = BTreeMap::new();
+        let mut map = Vec::new();
 
         if let Some(b) = self.value.take() {
-            map.insert(self.sep.to_owned(), b);
+            map.push((self.sep.to_owned(), b));
         }
 
         loop {
@@ -66,7 +65,7 @@ impl<'a, I> Iterator for Maps<'a, I>
                         }
                         break;
                     } else {
-                        map.insert(a, b);
+                        map.push((a, b));
                     }
                 }
                 Some(Err(e)) => return Some(Err(e)),
@@ -106,9 +105,12 @@ pub trait Proto {
     fn run_command<I>(&mut self, command: &str, arguments: I) -> Result<()> where I: ToArguments;
 
     fn read_structs<'a, T>(&'a mut self, key: &'static str) -> Result<Vec<T>>
-        where T: 'a + FromMap
+        where T: 'a + FromIter,
     {
-        self.read_pairs().split(key).map(|v| v.and_then(FromMap::from_map)).collect()
+        self.read_pairs()
+            .split(key)
+            .map(|v| v.and_then(|v| FromIter::from_iter(v.into_iter().map(Ok))))
+            .collect()
     }
 
     fn read_list(&mut self, key: &'static str) -> Result<Vec<String>> {

--- a/src/song.rs
+++ b/src/song.rs
@@ -5,7 +5,6 @@ use crate::error::{Error, ParseError};
 
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
-use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 use std::time::Duration;
@@ -112,7 +111,7 @@ pub struct Song {
     /// range to play (if queued for playback and range was set)
     pub range: Option<Range>,
     /// arbitrary tags, like album, artist etc
-    pub tags: BTreeMap<String, String>,
+    pub tags: Vec<(String, String)>,
 }
 
 impl Encodable for Song {
@@ -200,7 +199,7 @@ impl FromIter for Song {
                     }
                 }
                 _ => {
-                    result.tags.insert(line.0, line.1);
+                    result.tags.push((line.0, line.1));
                 }
             }
         }


### PR DESCRIPTION
Tags in MPD are not a key-value mapping, but an array of key-value
pairs. Some tags commonly have multiple values, such as PERFORMER, and
by storing this data in a map we only get one of the performers.