### PR TITLE
Fix liftimes in query API

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -55,7 +55,7 @@ impl<'a> Query<'a> {
         Query { filters: Vec::new() }
     }
 
-    pub fn and<'b: 'a, V: 'b + Into<Cow<'b, str>>>(&'a mut self, term: Term<'b>, value: V) -> &'a mut Query<'a> {
+    pub fn and<'b: 'a, V: 'b + Into<Cow<'b, str>>>(&mut self, term: Term<'b>, value: V) -> &mut Query<'a> {
         self.filters.push(Filter::new(term, value));
         self
     }
@@ -137,5 +137,12 @@ mod test {
         let finished = query.and(Term::Tag("albumartist".into()), "Mac DeMarco").and(Term::Tag("album".into()), "Salad Days");
         let output = collect(&*finished);
         assert_eq!(output, vec!["albumartist", "Mac DeMarco", "album", "Salad Days"]);
+    }
+
+    #[test]
+    fn multiple_and() {
+        let mut query = Query::new();
+        query.and(Term::Tag("albumartist".into()), "Mac DeMarco");
+        query.and(Term::Tag("album".into()), "Salad Days");
     }
 }


### PR DESCRIPTION
The provided test case fails to build on master, but seems like a valid
use case. See: https://stackoverflow.com/questions/58878192/cannot-borrow-xxx-as-mutable-more-than-once-at-a-time-when-using-mpds-query/58879004#58879004 and #40 for a discussion.