### PR TITLE
fix(client): find_sticker_eq missing `=` argument

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -600,7 +600,7 @@ impl<S: Read + Write> Client<S> {
     /// List all files of a given type under given directory (identified by uri)
     /// with a tag set to given value
     pub fn find_sticker_eq(&mut self, typ: &str, uri: &str, name: &str, value: &str) -> Result<Vec<String>> {
-        self.run_command("sticker find", (typ, uri, name, value)).and_then(|_| self.read_list("file"))
+        self.run_command("sticker find", (typ, uri, name, "=", value)).and_then(|_| self.read_list("file"))
     }
     // }}}
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -230,7 +230,8 @@ macro_rules! argument_for_tuple {
 argument_for_tuple!{t0: T0}
 argument_for_tuple!{t0: T0, t1: T1}
 argument_for_tuple!{t0: T0, t1: T1, t2: T2}
-argument_for_tuple!{t0: T0, t1: T1, t2: T2, t3:T3}
+argument_for_tuple!{t0: T0, t1: T1, t2: T2, t3: T3}
+argument_for_tuple!{t0: T0, t1: T1, t2: T2, t3:T3, t4: T4}
 
 impl<'a, T: ToArguments> ToArguments for &'a [T] {
     fn to_arguments<F, E>(&self, f: &mut F) -> StdResult<(), E>


### PR DESCRIPTION
Fixes `find_sticker_eq` always returning a bad request response due to the missing operator argument.

Worth noting the protocol also supports `>` or `<`, which are currently not mapped by the library