### PR TITLE
Fix Client.version doc comment

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -34,7 +34,7 @@ pub struct Client<S = TcpStream>
 where S: Read + Write
 {
     socket: BufStream<S>,
-    /// MPD version
+    /// MPD protocol version
     pub version: Version,
 }
 


### PR DESCRIPTION
The version returned on connection by MPD is the version of the protocol, not of the daemon.

See also: https://mpd.readthedocs.io/en/latest/protocol.html#protocol-overview