### PR TITLE
Add plugin name to output struct

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -11,6 +11,8 @@ use std::convert::From;
 pub struct Output {
     /// id
     pub id: u32,
+    /// name of the output plugin
+    pub plugin: String,
     /// name
     pub name: String,
     /// enabled state
@@ -21,6 +23,7 @@ impl FromMap for Output {
     fn from_map(map: BTreeMap<String, String>) -> Result<Output, Error> {
         Ok(Output {
             id: get_field!(map, "outputid"),
+            plugin: get_field!(map, "plugin"),
             name: map.get("outputname").map(|v| v.to_owned()).ok_or(Error::Proto(ProtoError::NoField("outputname")))?,
             enabled: get_field!(map, bool "outputenabled"),
         })

--- a/tests/outputs.rs
+++ b/tests/outputs.rs
@@ -6,7 +6,15 @@ use helpers::connect;
 #[test]
 fn outputs() {
     let mut mpd = connect();
-    println!("{:?}", mpd.outputs());
+
+    let outputs = mpd.outputs().unwrap();
+    assert_eq!(outputs.len(), 1);
+
+    let null_output = outputs.first().unwrap();
+    assert_eq!(null_output.id, 0);
+    assert_eq!(null_output.plugin, "null");
+    assert_eq!(null_output.name, "null");
+    assert!(null_output.enabled);
 }
 
 #[test]


### PR DESCRIPTION
The `plugin` field returned by the [`outputs` command](https://mpd.readthedocs.io/en/stable/protocol.html#command-outputs) is currently missing.