### PR TITLE
Set null mixer type for test audio output

### DIFF
--- a/tests/helpers/daemon.rs
+++ b/tests/helpers/daemon.rs
@@ -43,6 +43,7 @@ bind_to_address "{sock_path}"
 audio_output {{
     type "null"
     name "null"
+    mixer_type "null"
 }}
 "#,
             db_file = self.db_file.display(),


### PR DESCRIPTION
Currently, the [`volume` test](https://github.com/kstep/rust-mpd/blob/c31a9ba36c9c5107da392e1cab17da9c0c5dee16/tests/options.rs#L51) fails with:

> thread 'volume' panicked at 'called `Result::unwrap()` on an `Err` value: Server(ServerError { code: UnknownCmd, pos: 0, command: "setvol", detail: "No mixer" })'

when trying to set volume, as the `null` audio output has no mixer.

The [`null` mixer](https://mpd.readthedocs.io/en/stable/user.html#configuring-audio-outputs) allows to set volume without actual effect.