### PR TITLE
Avoid `use Enum::*`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -81,22 +81,22 @@ impl StdError for ErrorCode {}
 
 impl fmt::Display for ErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ErrorCode::*;
+        use self::ErrorCode as E;
 
         let desc = match *self {
-            NotList => "not a list",
-            Argument => "invalid argument",
-            Password => "invalid password",
-            Permission => "permission",
-            UnknownCmd => "unknown command",
+            E::NotList => "not a list",
+            E::Argument => "invalid argument",
+            E::Password => "invalid password",
+            E::Permission => "permission",
+            E::UnknownCmd => "unknown command",
 
-            NoExist => "item not found",
-            PlaylistMax => "playlist overflow",
-            System => "system",
-            PlaylistLoad => "playload load",
-            UpdateAlready => "already updating",
-            PlayerSync => "player syncing",
-            Exist => "already exists",
+            E::NoExist => "item not found",
+            E::PlaylistMax => "playlist overflow",
+            E::System => "system",
+            E::PlaylistLoad => "playload load",
+            E::UpdateAlready => "already updating",
+            E::PlayerSync => "player syncing",
+            E::Exist => "already exists",
         };
 
         f.write_str(desc)
@@ -276,27 +276,27 @@ impl StdError for ParseError {}
 
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ParseError::*;
+        use self::ParseError as E;
 
         let desc = match *self {
-            BadInteger(_) => "invalid integer",
-            BadFloat(_) => "invalid float",
-            BadValue(_) => "invalid value",
-            BadVersion => "invalid version",
-            NotAck => "not an ACK",
-            BadPair => "invalid pair",
-            BadCode => "invalid code",
-            BadPos => "invalid position",
-            NoCodePos => "missing code and position",
-            NoMessage => "missing position",
-            NoRate => "missing audio format rate",
-            NoBits => "missing audio format bits",
-            NoChans => "missing audio format channels",
-            BadRate(_) => "invalid audio format rate",
-            BadBits(_) => "invalid audio format bits",
-            BadChans(_) => "invalid audio format channels",
-            BadState(_) => "invalid playing state",
-            BadErrorCode(_) => "unknown error code",
+            E::BadInteger(_) => "invalid integer",
+            E::BadFloat(_) => "invalid float",
+            E::BadValue(_) => "invalid value",
+            E::BadVersion => "invalid version",
+            E::NotAck => "not an ACK",
+            E::BadPair => "invalid pair",
+            E::BadCode => "invalid code",
+            E::BadPos => "invalid position",
+            E::NoCodePos => "missing code and position",
+            E::NoMessage => "missing position",
+            E::NoRate => "missing audio format rate",
+            E::NoBits => "missing audio format bits",
+            E::NoChans => "missing audio format channels",
+            E::BadRate(_) => "invalid audio format rate",
+            E::BadBits(_) => "invalid audio format bits",
+            E::BadChans(_) => "invalid audio format channels",
+            E::BadState(_) => "invalid playing state",
+            E::BadErrorCode(_) => "unknown error code",
         };
 
         write!(f, "{}", desc)

--- a/src/idle.rs
+++ b/src/idle.rs
@@ -96,22 +96,22 @@ impl FromStr for Subsystem {
 
 impl Subsystem {
     fn to_str(self) -> &'static str {
-        use self::Subsystem::*;
+        use self::Subsystem as S;
         match self {
-            Database => "database",
-            Update => "update",
-            Playlist => "stored_playlist",
-            Queue => "playlist",
-            Player => "player",
-            Mixer => "mixer",
-            Output => "output",
-            Options => "options",
-            Partition => "partition",
-            Sticker => "sticker",
-            Subscription => "subscription",
-            Message => "message",
-            Neighbor => "neighbor",
-            Mount => "mount",
+            S::Database => "database",
+            S::Update => "update",
+            S::Playlist => "stored_playlist",
+            S::Queue => "playlist",
+            S::Player => "player",
+            S::Mixer => "mixer",
+            S::Output => "output",
+            S::Options => "options",
+            S::Partition => "partition",
+            S::Sticker => "sticker",
+            S::Subscription => "subscription",
+            S::Message => "message",
+            S::Neighbor => "neighbor",
+            S::Mount => "mount",
         }
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -203,12 +203,12 @@ impl FromStr for ReplayGain {
 
 impl fmt::Display for ReplayGain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ReplayGain::*;
+        use self::ReplayGain as R;
         f.write_str(match *self {
-            Off => "off",
-            Track => "track",
-            Album => "album",
-            Auto => "auto",
+            R::Off => "off",
+            R::Track => "track",
+            R::Album => "album",
+            R::Auto => "auto",
         })
     }
 }


### PR DESCRIPTION
The `use Enum::*` for enums in `match` blocks to avoid repeating the enum name can be a footgun in case a variant is later removed - inside the `match` block the removed variant becomes a catchall variant.

And if one variant is removed and another is added, the removed variant will catch the newly added one, without us needing to handle the newly added variant.

For a better explanation: https://youtu.be/8j_FbjiowvE?t=97