### PR TITLE
Use `tempfile` crate instead of `tempdir`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_repr = { version = "0.1", optional = true }
 
 [dev-dependencies]
-tempdir = "0.3.5"
+tempfile = "3.8.1"
 unix_socket = "0.5.0"
 
 [features]

--- a/tests/helpers/daemon.rs
+++ b/tests/helpers/daemon.rs
@@ -1,6 +1,6 @@
-extern crate tempdir;
+extern crate tempfile;
 
-use self::tempdir::TempDir;
+use self::tempfile::TempDir;
 use super::mpd;
 use std::fs::{create_dir, File};
 use std::io::{Read, Write};
@@ -92,7 +92,7 @@ static EMPTY_FLAC_BYTES: &[u8] = include_bytes!("../data/empty.flac");
 
 impl Daemon {
     pub fn start() -> Daemon {
-        let temp_dir = TempDir::new("mpd-test").unwrap();
+        let temp_dir = TempDir::with_prefix("mpd-test").unwrap();
         let config = MpdConfig::new(&temp_dir);
         config.generate();
 


### PR DESCRIPTION
`tempdir` was merged into [`tempfile`](https://crates.io/crates/tempfile) and [is now deprecated](https://github.com/rust-lang-deprecated/tempdir#deprecation-note).