### PR TITLE
Drop `unix_socket` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ serde_repr = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.5"
-unix_socket = "0.5.0"
 
 [features]
 serde = ["dep:serde", "dep:serde_repr"]

--- a/benches/options.rs
+++ b/benches/options.rs
@@ -3,10 +3,9 @@
 extern crate mpd;
 extern crate test;
 extern crate time;
-extern crate unix_socket;
 
+use std::os::unix::net::UnixStream;
 use test::{black_box, Bencher};
-use unix_socket::UnixStream;
 
 #[bench]
 fn status(b: &mut Bencher) {

--- a/benches/options.rs
+++ b/benches/options.rs
@@ -2,7 +2,6 @@
 
 extern crate mpd;
 extern crate test;
-extern crate time;
 
 use std::os::unix::net::UnixStream;
 use test::{black_box, Bencher};


### PR DESCRIPTION
I believe this is leftover as `std::os::unix::net::UnixStream` is [already being used](https://github.com/kstep/rust-mpd/blob/5765e02bbc3b6c1dc2571ac6e44f53402972fe68/tests/helpers/daemon.rs#L7) in tests.