### PR TITLE
Improve test daemon logging

### DIFF
--- a/tests/helpers/daemon.rs
+++ b/tests/helpers/daemon.rs
@@ -35,7 +35,6 @@ impl MpdConfig {
         format!(
             r#"
 db_file "{db_file}"
-log_file "/dev/null"
 music_directory "{music_directory}"
 playlist_directory "{playlist_directory}"
 sticker_file "{sticker_file}"
@@ -76,8 +75,7 @@ impl Drop for Daemon {
         if let Some(ref mut stderr) = self.process.stderr {
             let mut output = String::new();
             stderr.read_to_string(&mut output).expect("Could not collect output from mpd.");
-            println! {"Output from mpd:"}
-            println! {"{}", output};
+            println!("Output from mpd:\n{output}");
         }
     }
 }
@@ -101,6 +99,8 @@ impl Daemon {
 
         let process = Command::new("mpd")
             .arg("--no-daemon")
+            .arg("--verbose")
+            .arg("--stderr")
             .arg(&config.config_path)
             .stdin(Stdio::null())
             .stdout(Stdio::null())


### PR DESCRIPTION
- Pass [`--verbose`](https://mpd.readthedocs.io/en/stable/mpd.1.html#cmdoption-mpd-verbose) so MPD outputs verbose logs (e.g. messages of interaction with the client), which can be useful in case of a test failure.
- Pass [`--stderr`](https://mpd.readthedocs.io/en/stable/mpd.1.html#cmdoption-mpd-stderr) so that MPD outputs all messages to stderr, which is what we capture.
- Drop `log_file "/dev/null"` directive from config, since we want to capture the logs from stderr.
- Use [standard macro braces](https://rust-lang.github.io/rust-clippy/master/index.html#/nonstandard_macro_braces).