### PR TITLE
Handle errors when creating duration from float

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,7 @@ use std::num::{ParseFloatError, ParseIntError};
 use std::result;
 use std::str::FromStr;
 use std::string::ParseError as StringParseError;
+use std::time::TryFromFloatSecsError;
 
 // Server errors {{{
 /// Server error codes, as defined in [libmpdclient](http://www.musicpd.org/doc/libmpdclient/protocol_8h_source.html)
@@ -219,6 +220,11 @@ impl From<ParseFloatError> for Error {
         Error::Parse(ParseError::BadFloat(e))
     }
 }
+impl From<TryFromFloatSecsError> for Error {
+    fn from(e: TryFromFloatSecsError) -> Error {
+        Error::Parse(ParseError::BadDuration(e))
+    }
+}
 impl From<ServerError> for Error {
     fn from(e: ServerError) -> Error {
         Error::Server(e)
@@ -235,6 +241,8 @@ pub enum ParseError {
     BadInteger(ParseIntError),
     /// invalid float
     BadFloat(ParseFloatError),
+    /// invalid duration (negative, too big or not a number)
+    BadDuration(TryFromFloatSecsError),
     /// some other invalid value
     BadValue(String),
     /// invalid version format (should be x.y.z)
@@ -281,6 +289,7 @@ impl fmt::Display for ParseError {
         let desc = match *self {
             E::BadInteger(_) => "invalid integer",
             E::BadFloat(_) => "invalid float",
+            E::BadDuration(_) => "invalid duration",
             E::BadValue(_) => "invalid value",
             E::BadVersion => "invalid version",
             E::NotAck => "not an ACK",
@@ -312,6 +321,12 @@ impl From<ParseIntError> for ParseError {
 impl From<ParseFloatError> for ParseError {
     fn from(e: ParseFloatError) -> ParseError {
         ParseError::BadFloat(e)
+    }
+}
+
+impl From<TryFromFloatSecsError> for ParseError {
+    fn from(e: TryFromFloatSecsError) -> ParseError {
+        ParseError::BadDuration(e)
     }
 }
 

--- a/src/song.rs
+++ b/src/song.rs
@@ -119,7 +119,7 @@ impl FromIter for Song {
                 "Name" => result.name = Some(line.1.to_owned()),
                 // Deprecated in MPD.
                 "Time" => (),
-                "duration" => result.duration = Some(Duration::from_secs_f64(line.1.parse()?)),
+                "duration" => result.duration = Some(Duration::try_from_secs_f64(line.1.parse()?)?),
                 "Range" => result.range = Some(line.1.parse()?),
                 "Id" => match result.place {
                     None => result.place = Some(QueuePlace { id: Id(line.1.parse()?), pos: 0, prio: 0 }),

--- a/src/status.rs
+++ b/src/status.rs
@@ -97,9 +97,8 @@ impl FromIter for Status {
                         _ => Ok(None),
                     }?;
                 }
-                // TODO" => float errors don't work on stable
-                "elapsed" => result.elapsed = line.1.parse::<f32>().ok().map(|v| Duration::from_millis((v * 1000.0) as u64)),
-                "duration" => result.duration = line.1.parse::<f32>().ok().map(|v| Duration::from_millis((v * 1000.0) as u64)),
+                "elapsed" => result.elapsed = Some(Duration::try_from_secs_f64(line.1.parse()?)?),
+                "duration" => result.duration = Some(Duration::try_from_secs_f64(line.1.parse()?)?),
                 "bitrate" => result.bitrate = Some(line.1.parse()?),
                 "xfade" => result.crossfade = Some(Duration::from_secs(line.1.parse()?)),
                 // "mixrampdb" => 0.0, //get_field!(map, "mixrampdb"),


### PR DESCRIPTION
- Use `Duration::try_from_secs_f64` when parsing duration with decimal point.
- Add new variant `BadDuration` to `ParserError` for handling the errors when the float value is not a valid duration (negative, would overflow the underlying `u64` or is not a number).
- Do not discard duration parsing errors with `.ok()`.