### PR TITLE
added listallinfo command

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -198,12 +198,12 @@ impl<S: Read + Write> Client<S> {
         self.run_command("playlistinfo", ()).and_then(|_| self.read_structs("file"))
     }
 
-    /// lists all songs in the database
+    /// Lists all songs in the database
     pub fn listall(&mut self) -> Result<Vec<Song>> {
         self.run_command("listall", ()).and_then(|_| self.read_structs("file"))
     }
 
-    /// lists all songs in the database with metadata
+    /// Lists all songs in the database with metadata
     pub fn listallinfo(&mut self) -> Result<Vec<Song>> {
         self.run_command("listallinfo", ()).and_then(|_| self.read_structs("file"))
     }
@@ -384,7 +384,7 @@ impl<S: Read + Write> Client<S> {
     // Database search {{{
     // TODO: count tag needle [...] [group] [grouptag], find type what [...] [window start:end]
     // TODO: search type what [...] [window start:end], searchadd type what [...]
-    // TODO: listallinfo [uri], listfiles [uri]
+    // TODO: listfiles [uri]
     // TODO: list type [filtertype] [filterwhat] [...] [group] [grouptype] [...]
     // TODO: searchaddpl name type what [...]
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -203,6 +203,11 @@ impl<S: Read + Write> Client<S> {
         self.run_command("listall", ()).and_then(|_| self.read_structs("file"))
     }
 
+    /// lists all songs in the database with metadata
+    pub fn listallinfo(&mut self) -> Result<Vec<Song>> {
+        self.run_command("listallinfo", ()).and_then(|_| self.read_structs("file"))
+    }
+
     /// Get current playing song
     pub fn currentsong(&mut self) -> Result<Option<Song>> {
         self.run_command("currentsong", ())


### PR DESCRIPTION
For a personal project of mine, I needed to have quick access to mpd "listallinfo" command. 
Since the mpd "listall" command was already implemented, and a Vec<Song> structure could already be built from the mpd response, I added the mpd "listallinfo" command. After testing the new command in my project, I had the behaviour I expected.
Let me know if I need to add more code for the pr to be valid.